### PR TITLE
Add GitHub issue templates & disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore-devops-process-task.yml
+++ b/.github/ISSUE_TEMPLATE/chore-devops-process-task.yml
@@ -1,0 +1,63 @@
+name: Chore / DevOps / process task
+description: Create a task for repository setup, tooling, CI/CD, documentation, or process improvements
+title: "[Chore] "
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the task
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Select the area affected by this task
+      options:
+        - Repository
+        - CI/CD
+        - Docker / local environment
+        - Testing / quality
+        - Documentation
+        - Team process
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this task needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included in this task?
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies / risks
+      description: Are there blockers, dependencies, or risks?
+
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definition of Done
+      description: What conditions must be met for this task to be considered complete?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_notes
+    attributes:
+      label: Additional notes
+      description: Anything else relevant

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-functional-task.yml
+++ b/.github/ISSUE_TEMPLATE/feature-functional-task.yml
@@ -1,0 +1,51 @@
+name: Feature / functional task
+description: Create a task for a new feature, functional change, or business logic implementation
+title: "[Feature] "
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the task
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is included in this task?
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What is explicitly not included?
+
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definition of Done
+      description: What conditions must be met for this task to be considered complete?
+      placeholder: |
+        - implementation is complete
+        - basic test coverage is added or updated
+        - documentation is updated if needed
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_notes
+    attributes:
+      label: Additional notes
+      description: Links, dependencies, API notes, mockups, or anything relevant

--- a/.github/ISSUE_TEMPLATE/research-analysis-task.yml
+++ b/.github/ISSUE_TEMPLATE/research-analysis-task.yml
@@ -1,0 +1,57 @@
+name: Research / analysis task
+description: Create a task for analysis, comparison, investigation, or design work
+title: "[Research] "
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the task
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this analysis needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What question should this task answer or what artifact should it produce?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What should be analyzed or prepared?
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverable
+    attributes:
+      label: Expected deliverable
+      description: What should be produced as the output of this task?
+    validations:
+      required: true
+
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definition of Done
+      description: What conditions must be met for this task to be considered complete?
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Links to sources, docs, related issues, or external materials


### PR DESCRIPTION
Add three issue templates (Chore / DevOps / process, Feature / functional, Research / analysis) under .github/ISSUE_TEMPLATE to standardize issue reporting and capture summary, context, scope, definition of done, and related metadata. Also add config.yml to disable blank issues.