### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+Briefly describe the purpose of this pull request and the problem it solves.
+
+## Linked issue
+Closes #
+
+## Scope of changes
+Describe the main changes included in this pull request.
+
+-
+-
+-
+
+## Testing status
+Describe how this was verified.
+
+- [ ] Tested locally
+- [ ] Relevant tests added
+- [ ] Existing tests pass
+- [ ] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable
+- [ ] Not applicable
+
+## Checklist
+- [ ] PR title is clear and meaningful
+- [ ] Linked issue is included
+- [ ] Scope matches the issue
+- [ ] No unrelated changes were added
+- [ ] Documentation updated if needed
+- [ ] Ready for review


### PR DESCRIPTION
Add a GitHub pull request template at .github/pull_request_template.md to standardize PR submissions. The template includes sections for Summary, Linked issue, Scope of changes, Testing status (with checklist items including a Docker Compose verification command), and a general checklist to ensure PR quality and readiness for review.