### PR TITLE
Add CI quality checks and code analysis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+*                               @lukaszjecek
+/.github/                       @lukaszjecek
+/README.md                      @lukaszjecek
+/CONTRIBUTING.md                @lukaszjecek
+/infra/                         @lukaszjecek
+/config-repo/                   @lukaszjecek
+/services/                      @lukaszjecek

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,27 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
 
 jobs:
-  build:
+  quality:
+    name: Quality - ${{ matrix.service }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        service:
-          - config-server
-          - service-registry
-          - reservation-service
+        include:
+          - service: config-server
+            sonar_project_key: kwatera-project_KWATERA_config-server
+          - service: service-registry
+            sonar_project_key: kwatera-project_KWATERA_service-registry
+          - service: reservation-service
+            sonar_project_key: kwatera-project_KWATERA_reservation-service
 
     defaults:
       run:
@@ -21,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Java 25
         uses: actions/setup-java@v4
@@ -29,8 +41,44 @@ jobs:
           java-version: '25'
           cache: maven
 
+      - name: Cache Sonar packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Make mvnw executable
         run: chmod +x mvnw
 
-      - name: Run tests
-        run: ./mvnw test
+      - name: Check formatting
+        run: ./mvnw -B -ntp spotless:check
+
+      - name: Build, test and generate coverage
+        run: ./mvnw -B -ntp clean verify
+
+      - name: Run SpotBugs
+        run: ./mvnw -B -ntp spotbugs:check
+
+      - name: SonarQube Cloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >
+          ./mvnw -B -ntp
+          org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar
+          -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+          -Dsonar.projectKey=${{ matrix.sonar_project_key }}
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.qualitygate.wait=true
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-${{ matrix.service }}
+          if-no-files-found: ignore
+          path: |
+            services/${{ matrix.service }}/target/site/jacoco/**
+            services/${{ matrix.service }}/target/surefire-reports/**
+            services/${{ matrix.service }}/target/failsafe-reports/**
+            services/${{ matrix.service }}/target/spotbugsXml.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,38 @@ Preferred convention:
 2. Define context, scope, and Definition of Done.
 3. Create a branch for the issue.
 4. Implement only the changes required by that issue.
-5. Open a pull request using the shared PR template.
-6. Link the issue in the PR description.
-7. Provide testing status and complete the checklist.
-8. Request review.
-9. Merge after review is complete.
+5. Run local quality checks with `.\scripts\quality\pre-PR-check.ps1`.
+6. Open a pull request using the shared PR template.
+7. Link the issue in the PR description.
+8. Provide testing status and complete the checklist.
+9. Request review.
+10. Merge after review is complete.
+
+
+## Local quality checks before PR
+
+Before opening a pull request, contributors should run the local quality check script:
+
+```powershell
+.\scripts\quality\pre-PR-check.ps1
+```
+
+The script currently runs the following checks for all Java services in the repository:
+
+- `spotless:check`
+- `clean verify`
+- `spotbugs:check`
+
+Purpose:
+
+- catch formatting or build problems before opening a PR
+- reduce avoidable CI failures
+- keep pull requests focused on implementation instead of basic quality fixes
+
+JaCoCo coverage reports are generated during `verify` and can be viewed locally in:
+
+- `services/config-server/target/site/jacoco/index.html`
+- `services/service-registry/target/site/jacoco/index.html`
+- `services/reservation-service/target/site/jacoco/index.html`
+
+These local checks are recommended before every PR, **but the final source of truth remains the GitHub Actions CI workflow**.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ Run the empty runtime environment with Docker Compose:
 docker compose -f infra/compose/docker-compose.yml up --build
 ```
 
+### Local quality checks before pull request
+
+Before opening a pull request, run local quality checks:
+
+```powershell
+.\scripts\quality\pre-PR-check.ps1
+```
+
+This script runs the current local quality gate for all Java services:
+
+- `spotless:check`
+- `clean verify`
+- `spotbugs:check`
+
+JaCoCo coverage reports are generated locally during `verify` and can be opened in a browser from:
+
+- `services/config-server/target/site/jacoco/index.html`
+- `services/service-registry/target/site/jacoco/index.html`
+- `services/reservation-service/target/site/jacoco/index.html`
+
 ### Useful URLs after startup:
 
 - Config Server health: ```http://localhost:8888/actuator/health```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker compose -f infra/compose/docker-compose.yml up --build
 
 ### Useful URLs after startup:
 
-Config Server health: http://localhost:8888/actuator/health
-Eureka dashboard: http://localhost:8761
-Reservation service ping: http://localhost:8080/api/ping
-Reservation service health: http://localhost:8080/actuator/health
+- Config Server health: ```http://localhost:8888/actuator/health```
+- Eureka dashboard: ```http://localhost:8761```
+- Reservation service ping: ```http://localhost:8080/api/ping```
+- Reservation service health: ```http://localhost:8080/actuator/health```

--- a/scripts/quality/Invoke-MavenVerify.ps1
+++ b/scripts/quality/Invoke-MavenVerify.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+. "$PSScriptRoot\common.ps1"
+
+Invoke-MavenInEachService `
+    -Arguments @("clean", "verify") `
+    -Label "Maven verify"

--- a/scripts/quality/Invoke-SpotBugsCheck.ps1
+++ b/scripts/quality/Invoke-SpotBugsCheck.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+. "$PSScriptRoot\common.ps1"
+
+Invoke-MavenInEachService `
+    -Arguments @("spotbugs:check") `
+    -Label "SpotBugs check"

--- a/scripts/quality/Invoke-SpotlessCheck.ps1
+++ b/scripts/quality/Invoke-SpotlessCheck.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+. "$PSScriptRoot\common.ps1"
+
+Invoke-MavenInEachService `
+    -Arguments @("spotless:check") `
+    -Label "Spotless check"

--- a/scripts/quality/common.ps1
+++ b/scripts/quality/common.ps1
@@ -1,0 +1,52 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$script:ServiceDirs = @(
+    "services/config-server",
+    "services/service-registry",
+    "services/reservation-service"
+)
+
+function Write-Step {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+
+    Write-Host ""
+    Write-Host "=== $Message ===" -ForegroundColor Cyan
+}
+
+function Invoke-MavenInEachService {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Label
+    )
+
+    foreach ($relativeDir in $script:ServiceDirs) {
+        $servicePath = Join-Path $script:RepoRoot $relativeDir
+
+        if (-not (Test-Path $servicePath)) {
+            throw "Service directory not found: $servicePath"
+        }
+
+        Write-Step "$Label -> $relativeDir"
+
+        Push-Location $servicePath
+        try {
+            & .\mvnw @Arguments
+            $exitCode = $LASTEXITCODE
+        }
+        finally {
+            Pop-Location
+        }
+
+        if ($exitCode -ne 0) {
+            throw "$Label failed in $relativeDir with exit code $exitCode."
+        }
+    }
+}

--- a/scripts/quality/pre-PR-check.ps1
+++ b/scripts/quality/pre-PR-check.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+
+$steps = @(
+    "Invoke-SpotlessCheck.ps1",
+    "Invoke-MavenVerify.ps1",
+    "Invoke-SpotBugsCheck.ps1"
+)
+
+Write-Host ""
+Write-Host "Starting local pre-PR quality checks..." -ForegroundColor Yellow
+
+foreach ($step in $steps) {
+    $scriptPath = Join-Path $PSScriptRoot $step
+    & $scriptPath
+}
+
+Write-Host ""
+Write-Host "All local pre-PR quality checks passed." -ForegroundColor Green

--- a/services/config-server/pom.xml
+++ b/services/config-server/pom.xml
@@ -29,6 +29,9 @@
 	<properties>
 		<java.version>25</java.version>
 		<spring-cloud.version>2025.1.1</spring-cloud.version>
+		<spotless.version>3.4.0</spotless.version>
+		<jacoco.version>0.8.14</jacoco.version>
+		<spotbugs.version>4.9.8.3</spotbugs.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -63,6 +66,63 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+								<format>HTML</format>
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>${spotless.version}</version>
+				<configuration>
+					<java>
+						<includes>
+							<include>src/main/java/**/*.java</include>
+							<include>src/test/java/**/*.java</include>
+						</includes>
+						<googleJavaFormat/>
+						<removeUnusedImports/>
+						<trimTrailingWhitespace/>
+						<endWithNewline/>
+					</java>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>${spotbugs.version}</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>Medium</threshold>
+					<failOnError>true</failOnError>
+					<xmlOutput>true</xmlOutput>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/services/config-server/src/main/java/io/github/kwatera_project/kwatera/config_server/ConfigServerApplication.java
+++ b/services/config-server/src/main/java/io/github/kwatera_project/kwatera/config_server/ConfigServerApplication.java
@@ -8,7 +8,7 @@ import org.springframework.cloud.config.server.EnableConfigServer;
 @SpringBootApplication
 public class ConfigServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ConfigServerApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(ConfigServerApplication.class, args);
+  }
 }

--- a/services/config-server/src/test/java/io/github/kwatera_project/kwatera/config_server/ConfigServerApplicationTests.java
+++ b/services/config-server/src/test/java/io/github/kwatera_project/kwatera/config_server/ConfigServerApplicationTests.java
@@ -6,8 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ConfigServerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+  @Test
+  void contextLoads() {}
 }

--- a/services/reservation-service/pom.xml
+++ b/services/reservation-service/pom.xml
@@ -29,6 +29,9 @@
 	<properties>
 		<java.version>25</java.version>
 		<spring-cloud.version>2025.1.1</spring-cloud.version>
+		<spotless.version>3.4.0</spotless.version>
+		<jacoco.version>0.8.14</jacoco.version>
+		<spotbugs.version>4.9.8.3</spotbugs.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -84,6 +87,63 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+								<format>HTML</format>
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>${spotless.version}</version>
+				<configuration>
+					<java>
+						<includes>
+							<include>src/main/java/**/*.java</include>
+							<include>src/test/java/**/*.java</include>
+						</includes>
+						<googleJavaFormat/>
+						<removeUnusedImports/>
+						<trimTrailingWhitespace/>
+						<endWithNewline/>
+					</java>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>${spotbugs.version}</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>Medium</threshold>
+					<failOnError>true</failOnError>
+					<xmlOutput>true</xmlOutput>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/PingController.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/PingController.java
@@ -1,19 +1,17 @@
 package io.github.kwatera_project.kwatera.reservation_service;
 
+import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RestController
 public class PingController {
 
-    @GetMapping("/api/ping")
-    public Map<String, String> ping() {
-        return Map.of(
-                "status", "ok",
-                "service", "reservation-service",
-                "project", "KWATERA"
-        );
-    }
+  @GetMapping("/api/ping")
+  public Map<String, String> ping() {
+    return Map.of(
+        "status", "ok",
+        "service", "reservation-service",
+        "project", "KWATERA");
+  }
 }

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/ReservationServiceApplication.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/ReservationServiceApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ReservationServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ReservationServiceApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(ReservationServiceApplication.class, args);
+  }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/ReservationServiceApplicationTests.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/ReservationServiceApplicationTests.java
@@ -6,8 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ReservationServiceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+  @Test
+  void contextLoads() {}
 }

--- a/services/service-registry/pom.xml
+++ b/services/service-registry/pom.xml
@@ -29,6 +29,9 @@
 	<properties>
 		<java.version>25</java.version>
 		<spring-cloud.version>2025.1.1</spring-cloud.version>
+		<spotless.version>3.4.0</spotless.version>
+		<jacoco.version>0.8.14</jacoco.version>
+		<spotbugs.version>4.9.8.3</spotbugs.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -63,6 +66,63 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+								<format>HTML</format>
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>${spotless.version}</version>
+				<configuration>
+					<java>
+						<includes>
+							<include>src/main/java/**/*.java</include>
+							<include>src/test/java/**/*.java</include>
+						</includes>
+						<googleJavaFormat/>
+						<removeUnusedImports/>
+						<trimTrailingWhitespace/>
+						<endWithNewline/>
+					</java>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>${spotbugs.version}</version>
+				<configuration>
+					<effort>Max</effort>
+					<threshold>Medium</threshold>
+					<failOnError>true</failOnError>
+					<xmlOutput>true</xmlOutput>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/services/service-registry/src/main/java/io/github/kwatera_project/kwatera/service_registry/ServiceRegistryApplication.java
+++ b/services/service-registry/src/main/java/io/github/kwatera_project/kwatera/service_registry/ServiceRegistryApplication.java
@@ -8,7 +8,7 @@ import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 @SpringBootApplication
 public class ServiceRegistryApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ServiceRegistryApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(ServiceRegistryApplication.class, args);
+  }
 }

--- a/services/service-registry/src/test/java/io/github/kwatera_project/kwatera/service_registry/ServiceRegistryApplicationTests.java
+++ b/services/service-registry/src/test/java/io/github/kwatera_project/kwatera/service_registry/ServiceRegistryApplicationTests.java
@@ -6,8 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ServiceRegistryApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+  @Test
+  void contextLoads() {}
 }


### PR DESCRIPTION
## Summary
Introduce repository ownership and expand CI to run quality gates and reporting. Adds `.github/CODEOWNERS` assigning @lukaszjecek, and enhances `.github/workflows/ci.yml` to run on `main`, include a matrix per service, fetch full history, cache Sonar, run Spotless formatting check, unit/integration tests with JaCoCo coverage, SpotBugs, and SonarCloud analysis, and upload reports. Adds Spotless, JaCoCo and SpotBugs properties and plugin configurations to the three service POMs (config-server, service-registry, reservation-service). Also tweaks `README` URL formatting.

## Linked issue
Closes #30 

## Scope of changes
Describe the main changes included in this pull request.

- add `.github/CODEOWNERS` and align repository review ownership with the current workflow
- replace the basic CI workflow with a service matrix running `spotless:check`, `clean verify`, `spotbugs:check`, and SonarCloud analysis
- add Maven plugin configuration for Spotless, JaCoCo, and SpotBugs in `config-server`, `service-registry`, and `reservation-service`

## Testing status
Describe how this was verified.

- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable
- [ ] Not applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] Ready for review