### PR TITLE
Add OpenAPI/Swagger to services and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,14 @@ Current authentication endpoints:
 - Auth service login: [http://localhost:8081/api/auth/login](http://localhost:8081/api/auth/login)
 - Auth service register: [http://localhost:8081/api/auth/register](http://localhost:8081/api/auth/register)
 
+#### OpenAPI / Swagger UI
+- Auth Service Swagger UI: [http://localhost:8081/swagger-ui.html](http://localhost:8081/swagger-ui.html)
+- Property Service Swagger UI: [http://localhost:8083/swagger-ui.html](http://localhost:8083/swagger-ui.html)
+- Reservation Service Swagger UI: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+
 > Demo users are seeded through database migrations for local testing.
 
 ## Additional documentation
 
 - [CI quality pipeline](docs/ci/CI_QUALITY_PIPELINE.md)
-
+- [Stage 2 API contract and local demo setup](docs/stage-2-api-and-demo.md)

--- a/docs/stage-2-api-and-demo.md
+++ b/docs/stage-2-api-and-demo.md
@@ -1,0 +1,44 @@
+# Stage 2 API contract and local demo setup
+
+## Local startup
+
+Run the local environment from the repository root:
+
+```bash
+docker compose -f infra/compose/docker-compose.yml up --build
+```
+
+## OpenAPI / Swagger UI
+
+After startup, API documentation is available at:
+
+- Auth Service: http://localhost:8081/swagger-ui.html
+- Property Service: http://localhost:8083/swagger-ui.html
+- Reservation Service: http://localhost:8080/swagger-ui.html
+
+Raw OpenAPI JSON is available at:
+
+- Auth Service: http://localhost:8081/v3/api-docs
+- Property Service: http://localhost:8083/v3/api-docs
+- Reservation Service: http://localhost:8080/v3/api-docs
+
+## Stage 2 demo flow
+
+1. Guest opens the frontend.
+2. Guest browses available properties.
+3. Guest opens property details and available units.
+4. Guest selects dates.
+5. System validates unit availability.
+6. Guest creates a reservation.
+7. Owner or admin opens the reservation overview.
+8. Owner or admin reviews reservations and their statuses.
+
+## Roles used in the MVP
+
+- `ADMIN`: can access administrative reservation overview.
+- `OWNER`: can access owner-side reservation overview for owned units.
+- `GUEST`: guest-facing user role for browsing and reservation flow.
+
+## Maintenance rule
+
+Every new or changed REST endpoint should be checked in Swagger UI before opening a pull request. If the generated description is unclear, the author should add OpenAPI annotations or improve DTO names and validation.

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 
         <spring-boot.version>4.0.5</spring-boot.version>
         <spring-cloud.version>2025.1.1</spring-cloud.version>
+        <springdoc.version>3.0.3</springdoc.version>
 
         <spotless.version>3.4.0</spotless.version>
         <jacoco.version>0.8.14</jacoco.version>

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -127,6 +127,7 @@
                         <exclude>**/model/**/*.class</exclude>
                         <exclude>**/dto/**/*.class</exclude>
                         <exclude>**/mapper/**/*.class</exclude>
+                        <exclude>**/config/OpenApiConfig.class</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>auth-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
+    <properties>
+        <sonar.coverage.exclusions>**/config/OpenApiConfig.java</sonar.coverage.exclusions>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -103,6 +103,12 @@
             <version>0.12.5</version>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/OpenApiConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package io.github.kwatera_project.kwatera.auth_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI authServiceOpenApi() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("KWATERA Auth Service API")
+                                .version("Stage 2")
+                                .description("Authentication and user profile API for the KWATERA Stage 2 prototype."));
+    }
+}

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/OpenApiConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/OpenApiConfig.java
@@ -8,13 +8,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
-    @Bean
-    public OpenAPI authServiceOpenApi() {
-        return new OpenAPI()
-                .info(
-                        new Info()
-                                .title("KWATERA Auth Service API")
-                                .version("Stage 2")
-                                .description("Authentication and user profile API for the KWATERA Stage 2 prototype."));
-    }
+  @Bean
+  public OpenAPI authServiceOpenApi() {
+    return new OpenAPI()
+        .info(
+            new Info()
+                .title("KWATERA Auth Service API")
+                .version("Stage 2")
+                .description(
+                    "Authentication and user profile API for the KWATERA Stage 2 prototype."));
+  }
 }

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
@@ -35,6 +35,8 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/api/auth/**")
                     .permitAll()
+                    .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**")
+                    .permitAll()
                     .requestMatchers("/api/admin/**")
                     .hasRole("ADMIN")
                     .requestMatchers("/api/guest/**")

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/api/auth/**")
                     .permitAll()
-                    .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**")
+                    .requestMatchers(
+                        "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**")
                     .permitAll()
                     .requestMatchers("/api/admin/**")
                     .hasRole("ADMIN")

--- a/services/property-service/pom.xml
+++ b/services/property-service/pom.xml
@@ -94,6 +94,7 @@
                         <exclude>**/config/JpaConfig.class</exclude>
                         <exclude>**/model/**/*.class</exclude>
                         <exclude>**/mapper/**/*.class</exclude>
+                        <exclude>**/config/OpenApiConfig.class</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/services/property-service/pom.xml
+++ b/services/property-service/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>property-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
+    <properties>
+        <sonar.coverage.exclusions>**/config/OpenApiConfig.java</sonar.coverage.exclusions>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/services/property-service/pom.xml
+++ b/services/property-service/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>spring-boot-data-jpa-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/property-service/src/main/java/io/github/kwatera_project/kwatera/property_service/config/OpenApiConfig.java
+++ b/services/property-service/src/main/java/io/github/kwatera_project/kwatera/property_service/config/OpenApiConfig.java
@@ -8,13 +8,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
-    @Bean
-    public OpenAPI propertyServiceOpenApi() {
-        return new OpenAPI()
-                .info(
-                        new Info()
-                                .title("KWATERA Property Service API")
-                                .version("Stage 2")
-                                .description("Property, unit, and image catalogue API for the KWATERA Stage 2 prototype."));
-    }
+  @Bean
+  public OpenAPI propertyServiceOpenApi() {
+    return new OpenAPI()
+        .info(
+            new Info()
+                .title("KWATERA Property Service API")
+                .version("Stage 2")
+                .description(
+                    "Property, unit, and image catalogue API for the KWATERA Stage 2 prototype."));
+  }
 }

--- a/services/property-service/src/main/java/io/github/kwatera_project/kwatera/property_service/config/OpenApiConfig.java
+++ b/services/property-service/src/main/java/io/github/kwatera_project/kwatera/property_service/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package io.github.kwatera_project.kwatera.property_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI propertyServiceOpenApi() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("KWATERA Property Service API")
+                                .version("Stage 2")
+                                .description("Property, unit, and image catalogue API for the KWATERA Stage 2 prototype."));
+    }
+}

--- a/services/reservation-service/pom.xml
+++ b/services/reservation-service/pom.xml
@@ -131,6 +131,7 @@
                         <exclude>**/ReservationServiceApplication.class</exclude>
                         <exclude>**/config/JpaConfig.class</exclude>
                         <exclude>**/mapper/**/*.class</exclude>
+                        <exclude>**/config/OpenApiConfig.class</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/services/reservation-service/pom.xml
+++ b/services/reservation-service/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>reservation-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
+    <properties>
+        <sonar.coverage.exclusions>**/config/OpenApiConfig.java</sonar.coverage.exclusions>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/services/reservation-service/pom.xml
+++ b/services/reservation-service/pom.xml
@@ -110,6 +110,11 @@
             <scope>runtime</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/OpenApiConfig.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/OpenApiConfig.java
@@ -1,0 +1,21 @@
+package io.github.kwatera_project.kwatera.reservation_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI reservationServiceOpenApi() {
+    return new OpenAPI()
+        .info(
+            new Info()
+                .title("KWATERA Reservation Service API")
+                .version("Stage 2")
+                .description(
+                    "Availability and reservation overview API for the KWATERA Stage 2 prototype."));
+  }
+}


### PR DESCRIPTION
## Summary
Expose OpenAPI/Swagger UI across services: 
- add springdoc version property to root `pom.xml` and `springdoc-openapi-starter-webmvc-ui` dependency to `auth-`, `property-`, and `reservation-service` poms. 
- Add OpenApiConfig classes for Auth, Property and Reservation services to provide basic API metadata. 
- Update auth service SecurityConfig to allow unauthenticated access to Swagger and API docs endpoints. 
- Update `README.md` with Swagger UI links and add `docs/stage-2-api-and-demo.md` describing local startup, Swagger endpoints, stage-2 demo flow and roles. 

This enables browsing generated API docs and enforces checking Swagger during endpoint changes.

## Linked issue
Closes #27 

## Scope of changes

- Added springdoc OpenAPI/Swagger UI support for Stage 2 API services: auth-service, property-service, and reservation-service.
- Added OpenAPI metadata configuration for documented services, including API titles, descriptions, and Stage 2 version labels.
- Updated auth-service security configuration to allow access to Swagger UI and OpenAPI JSON endpoints without authentication.
- Added Stage 2 API and demo setup documentation with Swagger UI links, local startup instructions, demo flow, roles, reservation statuses, and API documentation maintenance rule.
- Updated README with links to Stage 2 API documentation and Swagger UI endpoints.

## Testing status
Describe how this was verified.

- [x] Tested locally
- [ ] Relevant tests added
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable
- [ ] Not applicable

Verified generated OpenAPI JSON manually via:
- http://localhost:8081/v3/api-docs
- http://localhost:8083/v3/api-docs
- http://localhost:8080/v3/api-docs

Ran `.\scripts\quality\pre-PR-check.ps1` successfully.

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] Ready for review