### PR TITLE
Add Stage 2 demo checklist and flow test

### DIFF
--- a/docs/demo/stage-2-demo-verification-checklist.md
+++ b/docs/demo/stage-2-demo-verification-checklist.md
@@ -1,0 +1,42 @@
+# Stage 2 demo verification checklist
+
+## Scope
+
+Critical Stage 2 flow:
+
+- [ ] Guest can browse properties.
+- [ ] Guest can open property or unit details.
+- [ ] Guest can select a future date range.
+- [ ] System validates availability.
+- [ ] Guest can create a reservation.
+- [ ] Owner or admin can open reservation overview.
+- [ ] Owner or admin can change reservation status.
+- [ ] Updated reservation status is visible after change.
+
+## Local startup
+
+- [ ] Docker is running.
+- [ ] Local environment starts successfully:
+
+```bash
+docker compose -f infra/compose/docker-compose.yml up --build
+```
+
+- [ ] Frontend opens at http://localhost:5173.
+- [ ] Reservation Service health endpoint works at http://localhost:8080/actuator/health.
+- [ ] Swagger UI opens at http://localhost:8080/swagger-ui.html.
+
+## Automated checks
+
+Run from `services/reservation-service`:
+
+```bash
+./mvnw -B -ntp test
+```
+
+- [ ] Reservation service tests pass.
+- [ ] Availability validation is covered.
+- [ ] Reservation creation is covered.
+- [ ] Status update is covered.
+- [ ] Critical Stage 2 flow is covered by `Stage2ReservationFlowTest`.
+

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
@@ -1,0 +1,113 @@
+package io.github.kwatera_project.kwatera.reservation_service.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.kwatera_project.kwatera.reservation_service.dto.AvailabilityDto;
+import io.github.kwatera_project.kwatera.reservation_service.dto.CreateReservationRequest;
+import io.github.kwatera_project.kwatera.reservation_service.dto.ReservationOverviewDto;
+import io.github.kwatera_project.kwatera.reservation_service.model.Reservation;
+import io.github.kwatera_project.kwatera.reservation_service.model.ReservationStatus;
+import io.github.kwatera_project.kwatera.reservation_service.model.ReservationStatusHistory;
+import io.github.kwatera_project.kwatera.reservation_service.repository.ReservationRepository;
+import io.github.kwatera_project.kwatera.reservation_service.repository.ReservationStatusHistoryRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class Stage2ReservationFlowTest {
+
+  @Mock private ReservationRepository reservationRepository;
+
+  @Mock private ReservationStatusHistoryRepository statusHistoryRepository;
+
+  @Mock private ReservationStatusValidator statusValidator;
+
+  @Mock private RestTemplate restTemplate;
+
+  private ReservationService reservationService;
+
+  private AdminReservationService adminReservationService;
+
+  @BeforeEach
+  void setUp() {
+    reservationService = new ReservationService(reservationRepository);
+    adminReservationService =
+        new AdminReservationService(
+            reservationRepository, statusHistoryRepository, statusValidator);
+    ReflectionTestUtils.setField(adminReservationService, "restTemplate", restTemplate);
+  }
+
+  @Test
+  void shouldCompleteCriticalStage2FlowFromAvailabilityToReservationStatusUpdate() {
+    UUID reservationId = UUID.randomUUID();
+    UUID guestId = UUID.randomUUID();
+    UUID adminId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    LocalDate startDate = LocalDate.now().plusDays(14);
+    LocalDate endDate = startDate.plusDays(4);
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(startDate);
+    request.setEndDate(endDate);
+
+    when(reservationRepository.findByUnitId(unitId)).thenReturn(List.of());
+    when(reservationRepository.save(any(Reservation.class)))
+        .thenAnswer(
+            invocation -> {
+              Reservation reservation = invocation.getArgument(0);
+              if (reservation.getId() == null) {
+                reservation.setId(reservationId);
+              }
+              return reservation;
+            });
+
+    AvailabilityDto availability = reservationService.checkAvailability(unitId, startDate, endDate);
+
+    Reservation createdReservation = reservationService.createReservation(guestId, request);
+
+    when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(createdReservation));
+
+    ReservationOverviewDto updatedReservation =
+        adminReservationService.updateReservationStatus(
+            reservationId, ReservationStatus.CONFIRMED, adminId, true);
+
+    assertThat(availability.isAvailable()).isTrue();
+    assertThat(createdReservation.getId()).isEqualTo(reservationId);
+    assertThat(createdReservation.getUserId()).isEqualTo(guestId);
+    assertThat(createdReservation.getUnitId()).isEqualTo(unitId);
+    assertThat(createdReservation.getStartDate()).isEqualTo(startDate);
+    assertThat(createdReservation.getEndDate()).isEqualTo(endDate);
+    assertThat(updatedReservation.status()).isEqualTo(ReservationStatus.CONFIRMED);
+
+    verify(reservationRepository, times(2)).findByUnitId(unitId);
+    verify(statusValidator)
+        .validateTransition(ReservationStatus.PENDING, ReservationStatus.CONFIRMED);
+    verify(reservationRepository, times(2)).save(any(Reservation.class));
+
+    ArgumentCaptor<ReservationStatusHistory> historyCaptor =
+        ArgumentCaptor.forClass(ReservationStatusHistory.class);
+    verify(statusHistoryRepository).save(historyCaptor.capture());
+
+    ReservationStatusHistory history = historyCaptor.getValue();
+    assertThat(history.getReservationId()).isEqualTo(reservationId);
+    assertThat(history.getOldStatus()).isEqualTo(ReservationStatus.PENDING);
+    assertThat(history.getNewStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    assertThat(history.getChangedBy()).isEqualTo(adminId);
+    assertThat(history.getChangedAt()).isNotNull();
+  }
+}


### PR DESCRIPTION
## Summary
Add a Stage 2 demo verification checklist (`docs/demo/stage-2-demo-verification-checklist.md`) with local startup steps and automated test instructions. 
Introduce Stage2ReservationFlowTest (`services/reservation-service/src/test/...`) to exercise the critical Stage 2 flow: 
- availability check, 
- reservation creation, 
- admin status update,
- status history persistence; 
The test also verifies repository interactions and status transition validation to ensure the critical service-layer flow is covered by automated tests.

## Linked issue
Closes #28 

## Scope of changes
- Added `Stage2ReservationFlowTest` for the critical Stage 2 reservation flow.
- Covered availability validation, reservation creation, admin status update, and status history persistence in one automated test.
- Verified repository interactions and status transition validation with Mockito.
- Added `docs/demo/stage-2-demo-verification-checklist.md` for final manual demo verification.
- Documented local Docker startup and reservation-service test command in the checklist.

## Testing status
Describe how this was verified.

- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable
- [ ] Not applicable

Manual frontend demo flow was verified locally through Docker Compose.

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] Ready for review