### PR TITLE
Expand CODEOWNERS and update contributing docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,54 @@
-*                               @lukaszjecek
-/.github/                       @lukaszjecek
-/README.md                      @lukaszjecek
-/CONTRIBUTING.md                @lukaszjecek
-/infra/                         @lukaszjecek
-/config-repo/                   @lukaszjecek
-/services/                      @lukaszjecek
+# Default fallback.
+* @lukaszjecek
+
+# Repository governance, workflow and documentation.
+/.github/ @lukaszjecek
+/.github/CODEOWNERS @lukaszjecek
+/README.md @lukaszjecek
+/CONTRIBUTING.md @lukaszjecek
+/docs/ @lukaszjecek
+/scripts/ @lukaszjecek
+
+# Shared build, runtime and infrastructure.
+/pom.xml @lukaszjecek @sinadzeya
+/config-repo/ @lukaszjecek @sinadzeya
+/infra/ @lukaszjecek @sinadzeya
+/services/config-server/ @lukaszjecek @sinadzeya
+/services/service-registry/ @lukaszjecek @sinadzeya
+/services/api-gateway/ @lukaszjecek @sinadzeya
+
+# Authentication, authorization and security.
+/services/auth-service/ @sinadzeya @lukaszjecek
+
+# Database schema, migrations and seed data.
+/services/db-migrations/ @sinadzeya @lukaszjecek
+
+# Property catalog domain.
+/services/property-service/ @ZuzannaAdamczyk @lukaszjecek
+
+# Reservation domain and owner/admin reservation flow.
+/services/reservation-service/ @alicjaswiers @lukaszjecek
+
+# Frontend.
+/frontend/ @ZuzannaAdamczyk @alicjaswiers @sinadzeya @lukaszjecek
+
+# Frontend authentication flow.
+/frontend/src/components/LoginForm.tsx @sinadzeya @lukaszjecek
+/frontend/src/components/RegisterForm.tsx @sinadzeya @lukaszjecek
+/frontend/src/components/Logout.tsx @sinadzeya @lukaszjecek
+/frontend/src/components/ProtectedRoute.tsx @sinadzeya @alicjaswiers @lukaszjecek
+/frontend/src/utils/jwtUtils.ts @sinadzeya @alicjaswiers @lukaszjecek
+
+# Frontend property/catalog flow.
+/frontend/src/api/propertyApi.ts @ZuzannaAdamczyk @lukaszjecek
+/frontend/src/types/property.ts @ZuzannaAdamczyk @lukaszjecek
+/frontend/src/pages/PropertiesPage.tsx @ZuzannaAdamczyk @lukaszjecek
+/frontend/src/pages/PropertyDetailsPage.tsx @ZuzannaAdamczyk @alicjaswiers @lukaszjecek
+/frontend/src/components/Slider.tsx @ZuzannaAdamczyk @lukaszjecek
+/frontend/src/pages/HomePage.tsx @ZuzannaAdamczyk @lukaszjecek
+
+# Frontend reservation/admin flow.
+/frontend/src/api/reservationApi.ts @alicjaswiers @lukaszjecek
+/frontend/src/types/reservation.ts @alicjaswiers @lukaszjecek
+/frontend/src/pages/ReservationDetailsPage.tsx @alicjaswiers @lukaszjecek
+/frontend/src/components/AdminReservationList.tsx @alicjaswiers @lukaszjecek

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,5 @@ Describe how this was verified.
 - [ ] No unrelated changes were added
 - [ ] Documentation updated if needed
 - [ ] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
+- [ ] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
 - [ ] Ready for review

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,4 +26,5 @@ Describe how this was verified.
 - [ ] Scope matches the issue
 - [ ] No unrelated changes were added
 - [ ] Documentation updated if needed
+- [ ] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
 - [ ] Ready for review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,27 +41,46 @@ Minimum PR completion rules:
 
 Every pull request should be linked to its issue in the PR description.
 
-Use one of the standard closing keywords, for example:
+Use a closing keyword only when the pull request fully completes the issue, for example:
 
 `Closes #14`
 
+If the pull request implements only part of the issue, use a non-closing reference instead, for example:
+
+`Refs #14`
+
+or
+
+`Part of #14`
+
 Preferred convention:
-- one PR should address one main issue
-- if needed, additional related issues can be referenced in the description
-- if the PR is not intended to close the issue yet, reference the issue without a closing keyword
+- one issue may be completed by one or more pull requests
+- smaller focused PRs are preferred when an issue covers multiple independent changes
+- use `Closes #...` only in the PR that completes the issue
+- use `Refs #...` or `Part of #...` for partial PRs
+- unrelated changes must not be included in a PR, even if they are small
+
+## CODEOWNERS maintenance
+
+When a PR introduces a new service, module, directory, or clearly separated feature area, update `.github/CODEOWNERS` in the same PR.
 
 ## Recommended workflow
 
 1. Create an issue using the correct issue template.
 2. Define context, scope, and Definition of Done.
-3. Create a branch for the issue.
-4. Implement only the changes required by that issue.
-5. Run local quality checks with `.\scripts\quality\pre-PR-check.ps1`.
-6. Open a pull request using the shared PR template.
-7. Link the issue in the PR description.
-8. Provide testing status and complete the checklist.
-9. Request review.
-10. Merge after review is complete.
+3. Create a branch for the first focused part of the issue.
+4. Implement only the changes required by that branch scope.
+5. Check whether the change introduces a new service, module, directory, or clearly separated feature area.
+6. Update `.github/CODEOWNERS` in the same PR if ownership changes are needed.
+7. Run local quality checks with `.\scripts\quality\pre-PR-check.ps1`.
+8. Open a pull request using the shared PR template.
+9. Link the issue in the PR description:
+   - use `Refs #...` or `Part of #...` for partial PRs
+   - use `Closes #...` only when the PR completes the issue
+10. Provide testing status and complete the checklist.
+11. Request review.
+12. Merge after review is complete.
+13. Continue with another focused PR if the issue is not fully completed yet.
 
 
 ## Local quality checks before PR


### PR DESCRIPTION
## Summary
- Add a default fallback owner and detailed per-path ownership to `.github/CODEOWNERS` (services, frontend, APIs, and specific components).
- Update the PR template to remind authors to update CODEOWNERS when ownership changes and verify OpenAPI/Swagger when backend API contracts change.
- Revise `CONTRIBUTING.md` to clarify closing vs. referencing issues, encourage smaller focused PRs, add a CODEOWNERS maintenance section, and update the recommended workflow to require updating CODEOWNERS when introducing new services/modules.

## Linked issue
Closes #55 

## Scope of changes

- Updated `.github/CODEOWNERS` to reflect current repository areas and existing review ownership.
- Added a PR template checkbox reminding contributors to update CODEOWNERS when ownership changes are introduced.
- Updated `CONTRIBUTING.md` with CODEOWNERS maintenance rules and clarified partial PR linking conventions.
- Added a PR template checkbox reminding contributors to verify and update OpenAPI/Swagger when backend API contracts change.

## Testing status
Describe how this was verified.

~~- [ ] Tested locally~~ (not applicable)
~~- [ ] Relevant tests added~~ (not applicable)
- [x] Existing tests pass

~~- [ ] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable~~ (not applicable)
- [x] Not applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] Ready for review