### PR TITLE
Route traffic through API Gateway and enable CORS

### DIFF
--- a/docs/stage-2-api-and-demo.md
+++ b/docs/stage-2-api-and-demo.md
@@ -8,6 +8,28 @@ Run the local environment from the repository root:
 docker compose -f infra/compose/docker-compose.yml up --build
 ```
 
+## API entry point
+
+All application traffic is routed through the **API Gateway** at:
+
+```
+http://localhost:8090
+```
+
+The frontend (served at `http://localhost:5173`) sends all API calls to this address.
+Direct service ports (8080, 8081, 8083) are still exposed for developer tools (Swagger, debugging)
+but must **not** be used by application code.
+
+### Routes exposed through the gateway
+
+| Path prefix | Downstream service |
+|---|---|
+| `/api/auth/**` | auth-service |
+| `/api/v1/reservations/**` | reservation-service |
+| `/api/v1/admin/reservations/**` | reservation-service |
+| `/api/availability/**` | reservation-service |
+| `/api/properties/**` | property-service |
+
 ## OpenAPI / Swagger UI
 
 After startup, API documentation is available at:
@@ -42,3 +64,5 @@ Raw OpenAPI JSON is available at:
 ## Maintenance rule
 
 Every new or changed REST endpoint should be checked in Swagger UI before opening a pull request. If the generated description is unclear, the author should add OpenAPI annotations or improve DTO names and validation.
+
+New Stage 3 services (billing, pricing/weather, OCR) should register with Eureka and add a corresponding route in `services/api-gateway/src/main/resources/application.yaml` as part of their implementation PR.

--- a/frontend/src/api/apiConfig.ts
+++ b/frontend/src/api/apiConfig.ts
@@ -1,0 +1,5 @@
+/**
+ * Shared API configuration for the KWATERA frontend.
+ * All API calls must go through the API Gateway.
+ */
+export const GATEWAY_BASE_URL = "http://localhost:8090";

--- a/frontend/src/api/availabilityApi.ts
+++ b/frontend/src/api/availabilityApi.ts
@@ -1,4 +1,6 @@
-const API_URL = "http://localhost:8080/api";
+import { GATEWAY_BASE_URL } from "./apiConfig";
+
+const API_URL = `${GATEWAY_BASE_URL}/api`;
 
 export async function checkAvailability(unitId: string, from: string, to: string) {
     const res = await fetch(

--- a/frontend/src/api/propertyApi.ts
+++ b/frontend/src/api/propertyApi.ts
@@ -1,4 +1,6 @@
-const API_URL = "http://localhost:8083/api";
+import { GATEWAY_BASE_URL } from "./apiConfig";
+
+const API_URL = `${GATEWAY_BASE_URL}/api`;
 
 export async function getProperties() {
     const res = await fetch(`${API_URL}/properties`);

--- a/frontend/src/api/reservationApi.ts
+++ b/frontend/src/api/reservationApi.ts
@@ -1,4 +1,6 @@
-const API_URL = "http://localhost:8080/api/v1/reservations";
+import { GATEWAY_BASE_URL } from "./apiConfig";
+
+const API_URL = `${GATEWAY_BASE_URL}/api/v1/reservations`;
 
 export async function createReservation(unitId: string, from: string, to: string) {
     const token = localStorage.getItem("token");

--- a/frontend/src/components/AdminReservationList.tsx
+++ b/frontend/src/components/AdminReservationList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link } from "react-router-dom";
+import { GATEWAY_BASE_URL } from '../api/apiConfig';
 
 interface ReservationOverview {
     id: string;
@@ -14,7 +15,7 @@ export default function AdminReservationList() {
     const [reservations, setReservations] = useState<ReservationOverview[]>([]);
     const [statusFilter, setStatusFilter] = useState<string>("");
     const [message, setMessage] = useState<{ text: string, type: 'success' | 'error' } | null>(null);
-    const API_BASE_URL = "http://localhost:8080";
+    const API_BASE_URL = GATEWAY_BASE_URL;
 
     const fetchReservations = useCallback(() => {
         const url = statusFilter

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,4 +1,5 @@
 import '../App.css'
+import { GATEWAY_BASE_URL } from '../api/apiConfig'
 import {useState} from "react"
 import {useNavigate, Link} from "react-router-dom"
 
@@ -16,7 +17,7 @@ export default function LoginForm() {
         e.preventDefault()
 
         try {
-            const response = await fetch('http://localhost:8081/api/auth/login', {
+            const response = await fetch(`${GATEWAY_BASE_URL}/api/auth/login`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -1,4 +1,5 @@
 import '../App.css'
+import { GATEWAY_BASE_URL } from '../api/apiConfig'
 import {useState} from "react"
 import {useNavigate} from "react-router-dom";
 
@@ -18,7 +19,7 @@ export default function RegisterForm() {
         e.preventDefault()
 
         try {
-            const response = await fetch('http://localhost:8081/api/auth/register', {
+            const response = await fetch(`${GATEWAY_BASE_URL}/api/auth/register`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -27,7 +28,7 @@ export default function RegisterForm() {
             })
 
             if (response.ok) {
-                const loginRes = await fetch('http://localhost:8081/api/auth/login', {
+                const loginRes = await fetch(`${GATEWAY_BASE_URL}/api/auth/login`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -126,7 +126,9 @@ services:
       EUREKA_DEFAULT_ZONE: http://service-registry:8761/eureka
     depends_on:
       config-server:
-          condition: service_started
+          condition: service_healthy
+      service-registry:
+          condition: service_healthy
     restart: on-failure
 
   frontend:

--- a/services/api-gateway/src/main/java/io/github/kwatera_project/kwatera/api_gateway/config/SecurityConfig.java
+++ b/services/api-gateway/src/main/java/io/github/kwatera_project/kwatera/api_gateway/config/SecurityConfig.java
@@ -1,18 +1,40 @@
 package io.github.kwatera_project.kwatera.api_gateway.config;
 
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
 
+  /** Permit all at the gateway level. Auth/authorization is enforced by downstream services. */
   @Bean
   public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
-    return http.authorizeExchange(exchanges -> exchanges.anyExchange().authenticated())
-        .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+    return http.csrf(ServerHttpSecurity.CsrfSpec::disable)
+        .authorizeExchange(exchanges -> exchanges.anyExchange().permitAll())
         .build();
+  }
+
+  /**
+   * Gateway-level CORS filter. Covers OPTIONS preflight requests from the frontend before they
+   * reach any route predicate.
+   */
+  @Bean
+  public CorsWebFilter corsWebFilter() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:5174"));
+    config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return new CorsWebFilter(source);
   }
 }

--- a/services/api-gateway/src/main/resources/application.yaml
+++ b/services/api-gateway/src/main/resources/application.yaml
@@ -8,13 +8,48 @@ spring:
     import: optional:configserver:http://config-server:8888
   cloud:
     gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOrigins:
+              - "http://localhost:5173"
+              - "http://localhost:5174"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - PATCH
+              - DELETE
+              - OPTIONS
+            allowedHeaders:
+              - "*"
+            allowCredentials: true
       routes:
         - id: auth-service
-          uri: http://auth-service:8081
+          uri: lb://auth-service
           predicates:
             - Path=/api/auth/**
-          filters:
-            - TokenRelay
+
+        - id: reservation-service
+          uri: lb://reservation-service
+          predicates:
+            - Path=/api/v1/reservations/**
+
+        - id: reservation-service-admin
+          uri: lb://reservation-service
+          predicates:
+            - Path=/api/v1/admin/reservations/**
+
+        - id: reservation-service-availability
+          uri: lb://reservation-service
+          predicates:
+            - Path=/api/availability/**
+
+        - id: property-service
+          uri: lb://property-service
+          predicates:
+            - Path=/api/properties/**
+
   security:
     oauth2:
       client:

--- a/services/api-gateway/src/main/resources/application.yaml
+++ b/services/api-gateway/src/main/resources/application.yaml
@@ -8,31 +8,35 @@ spring:
     import: optional:configserver:http://config-server:8888
   cloud:
     gateway:
-      routes:
-        - id: auth-service
-          uri: lb://auth-service
-          predicates:
-            - Path=/api/auth/**
+      server:
+        webflux:
+          default-filters:
+            - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin RETAIN_FIRST
+          routes:
+            - id: auth-service
+              uri: lb://auth-service
+              predicates:
+                - Path=/api/auth,/api/auth/**
 
-        - id: reservation-service
-          uri: lb://reservation-service
-          predicates:
-            - Path=/api/v1/reservations/**
+            - id: reservation-service
+              uri: lb://reservation-service
+              predicates:
+                - Path=/api/v1/reservations,/api/v1/reservations/**
 
-        - id: reservation-service-admin
-          uri: lb://reservation-service
-          predicates:
-            - Path=/api/v1/admin/reservations/**
+            - id: reservation-service-admin
+              uri: lb://reservation-service
+              predicates:
+                - Path=/api/v1/admin/reservations,/api/v1/admin/reservations/**
 
-        - id: reservation-service-availability
-          uri: lb://reservation-service
-          predicates:
-            - Path=/api/availability/**
+            - id: reservation-service-availability
+              uri: lb://reservation-service
+              predicates:
+                - Path=/api/availability,/api/availability/**
 
-        - id: property-service
-          uri: lb://property-service
-          predicates:
-            - Path=/api/properties/**
+            - id: property-service
+              uri: lb://property-service
+              predicates:
+                - Path=/api/properties,/api/properties/**
 
 eureka:
   client:

--- a/services/api-gateway/src/main/resources/application.yaml
+++ b/services/api-gateway/src/main/resources/application.yaml
@@ -34,31 +34,6 @@ spring:
           predicates:
             - Path=/api/properties/**
 
-  security:
-    oauth2:
-      client:
-        provider:
-          platform-auth-server:
-            authorization-uri: http://localhost:8081/oauth2/authorize
-            token-uri: http://localhost:8081/oauth2/token
-            jwk-set-uri: http://localhost:8081/oauth2/jwks
-        registration:
-          gateway-client:
-            provider: platform-auth-server
-            client-id: gateway-client
-            client-secret: "secret"
-            client-authentication-method: client_secret_basic
-            authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8090/login/oauth2/code/gateway-client
-            scope:
-              - openid
-              - profile
-              - email
-
-      resourceserver:
-        jwt:
-          issuer-uri: http://localhost:8081
-
 eureka:
   client:
     serviceUrl:

--- a/services/api-gateway/src/main/resources/application.yaml
+++ b/services/api-gateway/src/main/resources/application.yaml
@@ -8,22 +8,6 @@ spring:
     import: optional:configserver:http://config-server:8888
   cloud:
     gateway:
-      globalcors:
-        cors-configurations:
-          '[/**]':
-            allowedOrigins:
-              - "http://localhost:5173"
-              - "http://localhost:5174"
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - PATCH
-              - DELETE
-              - OPTIONS
-            allowedHeaders:
-              - "*"
-            allowCredentials: true
       routes:
         - id: auth-service
           uri: lb://auth-service

--- a/services/reservation-service/pom.xml
+++ b/services/reservation-service/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/services/reservation-service/pom.xml
+++ b/services/reservation-service/pom.xml
@@ -13,7 +13,10 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-        <sonar.coverage.exclusions>**/config/OpenApiConfig.java</sonar.coverage.exclusions>
+        <sonar.coverage.exclusions>
+            **/config/OpenApiConfig.java,
+            **/config/RestTemplateConfig.java
+        </sonar.coverage.exclusions>
     </properties>
 
     <dependencies>
@@ -141,6 +144,7 @@
                         <exclude>**/config/JpaConfig.class</exclude>
                         <exclude>**/mapper/**/*.class</exclude>
                         <exclude>**/config/OpenApiConfig.class</exclude>
+                        <exclude>**/config/RestTemplateConfig.class</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/RestTemplateConfig.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/RestTemplateConfig.java
@@ -1,0 +1,17 @@
+package io.github.kwatera_project.kwatera.reservation_service.config;
+
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/** Provides a load-balanced RestTemplate that resolves lb:// URIs via Eureka. */
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  @LoadBalanced
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/RestTemplateConfig.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/RestTemplateConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
-/** Provides a load-balanced RestTemplate that resolves lb:// URIs via Eureka. */
+/** Provides a load-balanced RestTemplate that resolves service names via Eureka. */
 @Configuration
 public class RestTemplateConfig {
 

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
@@ -27,7 +27,7 @@ public class AdminReservationService {
 
   private final ReservationStatusValidator statusValidator;
 
-  private final RestTemplate restTemplate = new RestTemplate();
+  private final RestTemplate restTemplate;
 
   public List<ReservationOverviewDto> getReservationsOverview(
       UUID ownerId, ReservationStatus status, boolean isAdmin) {
@@ -41,7 +41,7 @@ public class AdminReservationService {
       return reservations.stream().map(this::mapToOverviewDto).toList();
     }
 
-    String propertyServiceUrl = "http://property-service:8083/api/properties/units/ids/" + ownerId;
+    String propertyServiceUrl = "http://property-service/api/properties/units/ids/" + ownerId;
 
     try {
       UUID[] unitIdsArray = restTemplate.getForObject(propertyServiceUrl, UUID[].class);
@@ -105,7 +105,7 @@ public class AdminReservationService {
   }
 
   private void verifyOwnerAccess(UUID ownerId, UUID unitId) {
-    String propertyServiceUrl = "http://property-service:8083/api/properties/units/ids/" + ownerId;
+    String propertyServiceUrl = "http://property-service/api/properties/units/ids/" + ownerId;
     try {
       UUID[] unitIdsArray = restTemplate.getForObject(propertyServiceUrl, UUID[].class);
       List<UUID> ownerUnitIds =
@@ -129,7 +129,7 @@ public class AdminReservationService {
 
     try {
       String unitUrl =
-          "http://property-service:8083/api/properties/units/" + reservation.getUnitId();
+          "http://property-service/api/properties/units/" + reservation.getUnitId();
       UnitNameDto unitDto = restTemplate.getForObject(unitUrl, UnitNameDto.class);
       if (unitDto != null && unitDto.name() != null) {
         unitName = unitDto.name();

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
@@ -128,8 +128,7 @@ public class AdminReservationService {
     String unitName = "Unknown Room";
 
     try {
-      String unitUrl =
-          "http://property-service/api/properties/units/" + reservation.getUnitId();
+      String unitUrl = "http://property-service/api/properties/units/" + reservation.getUnitId();
       UnitNameDto unitDto = restTemplate.getForObject(unitUrl, UnitNameDto.class);
       if (unitDto != null && unitDto.name() != null) {
         unitName = unitDto.name();

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -21,10 +21,12 @@ public class ReservationService {
 
   private final ReservationRepository reservationRepository;
 
-  private final RestTemplate restTemplate = new RestTemplate();
+  private final RestTemplate restTemplate;
 
-  public ReservationService(ReservationRepository reservationRepository) {
+  public ReservationService(
+      ReservationRepository reservationRepository, RestTemplate restTemplate) {
     this.reservationRepository = reservationRepository;
+    this.restTemplate = restTemplate;
   }
 
   public AvailabilityDto checkAvailability(UUID unitId, LocalDate from, LocalDate to) {
@@ -103,7 +105,7 @@ public class ReservationService {
   }
 
   private boolean ownerHasAccessToUnit(UUID ownerId, UUID unitId) {
-    String propertyServiceUrl = "http://property-service:8083/api/properties/units/ids/" + ownerId;
+    String propertyServiceUrl = "http://property-service/api/properties/units/ids/" + ownerId;
 
     try {
       UUID[] unitIdsArray = restTemplate.getForObject(propertyServiceUrl, UUID[].class);

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,17 +18,12 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
 public class ReservationService {
 
   private final ReservationRepository reservationRepository;
 
   private final RestTemplate restTemplate;
-
-  public ReservationService(
-      ReservationRepository reservationRepository, RestTemplate restTemplate) {
-    this.reservationRepository = reservationRepository;
-    this.restTemplate = restTemplate;
-  }
 
   public AvailabilityDto checkAvailability(UUID unitId, LocalDate from, LocalDate to) {
     if (from == null || to == null) {

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
@@ -24,7 +24,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -191,8 +190,7 @@ class AdminReservationServiceTest {
     Reservation reservation = createReservation();
 
     when(restTemplate.getForObject(
-            eq("http://property-service/api/properties/units/ids/" + ownerId),
-            eq(UUID[].class)))
+            eq("http://property-service/api/properties/units/ids/" + ownerId), eq(UUID[].class)))
         .thenReturn(unitIds);
     when(reservationRepository.findByUnitIdIn(List.of(unitId))).thenReturn(List.of(reservation));
 

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
@@ -43,7 +43,7 @@ class AdminReservationServiceTest {
 
   @BeforeEach
   void setUp() {
-    ReflectionTestUtils.setField(adminReservationService, "restTemplate", restTemplate);
+    // restTemplate is injected via @InjectMocks (Lombok @RequiredArgsConstructor)
   }
 
   @Test
@@ -191,7 +191,7 @@ class AdminReservationServiceTest {
     Reservation reservation = createReservation();
 
     when(restTemplate.getForObject(
-            eq("http://property-service:8083/api/properties/units/ids/" + ownerId),
+            eq("http://property-service/api/properties/units/ids/" + ownerId),
             eq(UUID[].class)))
         .thenReturn(unitIds);
     when(reservationRepository.findByUnitIdIn(List.of(unitId))).thenReturn(List.of(reservation));

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
@@ -190,7 +190,7 @@ class AdminReservationServiceTest {
     Reservation reservation = createReservation();
 
     when(restTemplate.getForObject(
-            eq("http://property-service/api/properties/units/ids/" + ownerId), eq(UUID[].class)))
+            "http://property-service/api/properties/units/ids/" + ownerId, UUID[].class))
         .thenReturn(unitIds);
     when(reservationRepository.findByUnitIdIn(List.of(unitId))).thenReturn(List.of(reservation));
 

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -480,7 +480,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnMyReservations() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID userId = UUID.randomUUID();
     UUID reservationId = UUID.randomUUID();

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
 

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -28,7 +28,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnAvailableWhenNoReservations() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
 
@@ -44,7 +44,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnFalseWhenDatesOverlap() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
 
@@ -69,7 +69,7 @@ class ReservationServiceTest {
   @Test
   void shouldIgnoreCancelledReservation() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
 
@@ -92,7 +92,7 @@ class ReservationServiceTest {
 
   @Test
   void shouldThrowWhenDatesAreInvalid() {
-    ReservationService service = new ReservationService(null);
+    ReservationService service = new ReservationService(null, null);
 
     UUID id = UUID.randomUUID();
     LocalDate from = LocalDate.now().plusDays(5);
@@ -104,7 +104,7 @@ class ReservationServiceTest {
   @Test
   void shouldIgnoreCompletedReservation() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
 
@@ -128,7 +128,7 @@ class ReservationServiceTest {
   @Test
   void shouldAllowReservationStartingOnEndDate() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
 
@@ -150,7 +150,7 @@ class ReservationServiceTest {
   @Test
   void shouldCreateReservationSuccessfullyWhenDatesAreAvailable() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID userId = UUID.randomUUID();
     UUID unitId = UUID.randomUUID();
@@ -184,7 +184,7 @@ class ReservationServiceTest {
   @Test
   void shouldThrowConflictWhenTryingToReserveUnavailableDates() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID userId = UUID.randomUUID();
     UUID unitId = UUID.randomUUID();
@@ -217,7 +217,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnDetailsWhenUserOwnsReservation() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID reservationId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -245,7 +245,7 @@ class ReservationServiceTest {
   @Test
   void shouldThrowNotFoundWhenReservationDoesNotExist() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID reservationId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
@@ -263,7 +263,7 @@ class ReservationServiceTest {
   @Test
   void shouldThrowForbiddenWhenUserDoesNotOwnReservation() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID reservationId = UUID.randomUUID();
     UUID ownerId = UUID.randomUUID();
@@ -286,7 +286,7 @@ class ReservationServiceTest {
   @Test
   void shouldAllowViewingOtherUserReservationWhenHasManagementAccess() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID reservationId = UUID.randomUUID();
     UUID ownerId = UUID.randomUUID();
@@ -309,7 +309,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnAvailable_whenReservationEndsExactlyAtRequestedStart() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
     LocalDate requestedStart = LocalDate.now().plusDays(10);
@@ -330,7 +330,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnAvailable_whenReservationStartsExactlyAtRequestedEnd() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
     LocalDate requestedStart = LocalDate.now().plusDays(10);
@@ -351,7 +351,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnAvailable_whenReservationIsBeforeRequestedRange() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
     LocalDate requestedStart = LocalDate.now().plusDays(10);
@@ -372,7 +372,7 @@ class ReservationServiceTest {
   @Test
   void shouldReturnAvailable_whenReservationIsAfterRequestedRange() {
     ReservationRepository repository = mock(ReservationRepository.class);
-    ReservationService service = new ReservationService(repository);
+    ReservationService service = new ReservationService(repository, mock(RestTemplate.class));
 
     UUID unitId = UUID.randomUUID();
     LocalDate requestedStart = LocalDate.now().plusDays(10);
@@ -394,8 +394,7 @@ class ReservationServiceTest {
   void shouldReturnDetailsWhenOwnerHasAccessToReservationUnit() {
     ReservationRepository repository = mock(ReservationRepository.class);
     RestTemplate restTemplate = mock(RestTemplate.class);
-    ReservationService service = new ReservationService(repository);
-    ReflectionTestUtils.setField(service, "restTemplate", restTemplate);
+    ReservationService service = new ReservationService(repository, restTemplate);
 
     UUID reservationId = UUID.randomUUID();
     UUID guestId = UUID.randomUUID();
@@ -425,8 +424,7 @@ class ReservationServiceTest {
   void shouldThrowForbiddenWhenOwnerDoesNotHaveAccessToReservationUnit() {
     ReservationRepository repository = mock(ReservationRepository.class);
     RestTemplate restTemplate = mock(RestTemplate.class);
-    ReservationService service = new ReservationService(repository);
-    ReflectionTestUtils.setField(service, "restTemplate", restTemplate);
+    ReservationService service = new ReservationService(repository, restTemplate);
 
     UUID reservationId = UUID.randomUUID();
     UUID guestId = UUID.randomUUID();
@@ -455,8 +453,7 @@ class ReservationServiceTest {
   void shouldThrowForbiddenWhenOwnerAccessVerificationFails() {
     ReservationRepository repository = mock(ReservationRepository.class);
     RestTemplate restTemplate = mock(RestTemplate.class);
-    ReservationService service = new ReservationService(repository);
-    ReflectionTestUtils.setField(service, "restTemplate", restTemplate);
+    ReservationService service = new ReservationService(repository, restTemplate);
 
     UUID reservationId = UUID.randomUUID();
     UUID guestId = UUID.randomUUID();

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
@@ -44,11 +44,10 @@ class Stage2ReservationFlowTest {
 
   @BeforeEach
   void setUp() {
-    reservationService = new ReservationService(reservationRepository);
+    reservationService = new ReservationService(reservationRepository, restTemplate);
     adminReservationService =
         new AdminReservationService(
-            reservationRepository, statusHistoryRepository, statusValidator);
-    ReflectionTestUtils.setField(adminReservationService, "restTemplate", restTemplate);
+            reservationRepository, statusHistoryRepository, statusValidator, restTemplate);
   }
 
   @Test

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## Summary
- Switch frontend API calls to the API Gateway (`GATEWAY_BASE_URL`), adding `frontend/api/apiConfig.ts` and updating API clients and components to use the gateway. 
- Update docs to document the gateway entry point and routes. 
- Configure the API Gateway to expose service routes (`lb:// URIs`) and add global CORS support; simplify gateway security to permit requests at the gateway level. 
- Make `reservation-service` load-balanced: add loadbalancer dependency, provide a `@LoadBalanced RestTemplate`, update service code to use service names (remove hardcoded ports), and adjust tests to inject or mock RestTemplate. 
- Tighten `docker-compose` startup conditions for services.

## Linked issue
Closes #58 

## Scope of changes
- Added a shared frontend API configuration in `frontend/api/apiConfig.ts` and routed frontend API calls through the API Gateway at `http://localhost:8090`.
- Updated frontend clients and components for auth, properties, availability, reservation creation and admin reservation management to stop using direct service ports.
- Added API Gateway routes for auth-service, reservation-service and property-service using Eureka discovery with `lb://` service URIs.
- Added gateway-level CORS configuration for the local frontend origins.
- Simplified API Gateway security so the gateway permits requests and downstream services remain responsible for authentication and authorization.
- Updated `reservation-service` inter-service calls to use service names instead of hardcoded internal ports.
- Added a `@LoadBalanced RestTemplate` bean in `reservation-service` and updated affected unit/integration tests to inject or mock it.
- Updated local API documentation with the gateway entry point and exposed route prefixes.
- Adjusted Docker Compose startup dependencies so gateway-dependent services wait for Config Server and Eureka health checks.

## Testing status
Describe how this was verified.

- [x] Tested locally
~- [ ] Relevant tests added~ N/A
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable


## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
- [x] Ready for review