### PR TITLE
Add user profile, first/last name & edit UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import ReservationDetailsPage from "./pages/ReservationDetailsPage";
 import MyReservationsPage from "./pages/MyReservationsPage";
 import PaymentCancelPage from "./pages/PaymentCancelPage";
 import OccupancyCalendarPage from "./pages/OccupancyCalendarPage";
+import ProfilePage from "./pages/ProfilePage";
 
 function App() {
     return (
@@ -50,6 +51,14 @@ function App() {
                     element={
                         <ProtectedRoute allowedRoles={[]}>
                             <ReservationDetailsPage />
+                        </ProtectedRoute>
+                    }
+                />
+                <Route
+                    path="/profile"
+                    element={
+                        <ProtectedRoute>
+                            <ProfilePage />
                         </ProtectedRoute>
                     }
                 />

--- a/frontend/src/api/userApi.ts
+++ b/frontend/src/api/userApi.ts
@@ -1,0 +1,51 @@
+import { GATEWAY_BASE_URL } from "./apiConfig";
+
+export interface UserProfile {
+    id: string;
+    username: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    role: string;
+}
+
+export async function getUserProfile(): Promise<UserProfile> {
+    const token = localStorage.getItem("token");
+    if (!token) {
+        throw new Error("No token found");
+    }
+
+    const res = await fetch(`${GATEWAY_BASE_URL}/api/auth/users/me`, {
+        headers: {
+            Authorization: `Bearer ${token}`
+        }
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to fetch user profile");
+    }
+
+    return res.json();
+}
+
+export async function updateUserProfile(firstName: string, lastName: string): Promise<UserProfile> {
+    const token = localStorage.getItem("token");
+    if (!token) {
+        throw new Error("No token found");
+    }
+
+    const res = await fetch(`${GATEWAY_BASE_URL}/api/auth/users/me`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ firstName, lastName })
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to update user profile");
+    }
+
+    return res.json();
+}

--- a/frontend/src/api/userApi.ts
+++ b/frontend/src/api/userApi.ts
@@ -1,7 +1,6 @@
 import { GATEWAY_BASE_URL } from "./apiConfig";
 
 export interface UserProfile {
-    id: string;
     username: string;
     firstName: string;
     lastName: string;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -47,6 +47,15 @@ export default function Navbar() {
                     Catalog
                 </Link>
 
+                {isLoggedIn && (
+                    <Link
+                        to="/profile"
+                        className="hover:text-[rgb(var(--color-burgundy))] transition"
+                    >
+                        Profile
+                    </Link>
+                )}
+
                 {isLoggedIn && userRoles.includes("ROLE_GUEST") && (
                     <Link
                         to="/my-reservations"

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -8,7 +8,9 @@ export default function RegisterForm() {
         username: '',
         email: '',
         password: '',
-        role: ''
+        role: '',
+        firstName: '',
+        lastName: ''
     })
 
     const navigate = useNavigate()
@@ -90,6 +92,23 @@ export default function RegisterForm() {
                             />
                             Guest
                         </label>
+
+                    </div>
+                    <div className="flex gap-4">
+                        <input
+                            type="text"
+                            placeholder="First Name"
+                            className="w-1/2 p-2 border rounded"
+                            onChange={e => setFormData({...formData, firstName: e.target.value})}
+                            required
+                        />
+                        <input
+                            type="text"
+                            placeholder="Last Name"
+                            className="w-1/2 p-2 border rounded"
+                            onChange={e => setFormData({...formData, lastName: e.target.value})}
+                            required
+                        />
                     </div>
                     <input
                         type="text"

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -20,8 +20,9 @@ export default function ProfilePage() {
             })
             .catch((err) => {
                 console.error(err);
-                setError(err.message || "Failed to load profile details.");
-                loading && setLoading(false);
+                const errMsg = err instanceof Error ? err.message : String(err);
+                setError(errMsg || "Failed to load profile details.");
+                setLoading(false);
             });
     }, []);
 
@@ -50,9 +51,10 @@ export default function ProfilePage() {
             const updated = await updateUserProfile(editFirstName.trim(), editLastName.trim());
             setProfile(updated);
             setIsEditing(false);
-        } catch (err: any) {
+        } catch (err) {
             console.error(err);
-            setSaveError(err.message || "Failed to update profile details.");
+            const errMsg = err instanceof Error ? err.message : "Failed to update profile details.";
+            setSaveError(errMsg);
         } finally {
             setSaving(false);
         }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -116,6 +116,42 @@ export default function ProfilePage() {
         }
     };
 
+    const getRoleColor = (role: string) => {
+        switch (role.toUpperCase()) {
+            case "ADMIN":
+                return "bg-blue-100 text-blue-700";
+            case "OWNER":
+                return "bg-amber-100 text-amber-700";
+            case "GUEST":
+            default:
+                return "bg-emerald-100 text-emerald-700";
+        }
+    };
+
+    const getRoleIcon = (role: string) => {
+        switch (role.toUpperCase()) {
+            case "ADMIN":
+                return (
+                    <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                    </svg>
+                );
+            case "OWNER":
+                return (
+                    <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+                    </svg>
+                );
+            case "GUEST":
+            default:
+                return (
+                    <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                    </svg>
+                );
+        }
+    };
+
     return (
         <div className="p-6 max-w-7xl mx-auto text-[#1A1A1A]">
             <div className="mb-8">
@@ -123,31 +159,29 @@ export default function ProfilePage() {
                 <p className="text-sm text-[#7A7A7A]">{getRoleDescription(userRole)}</p>
             </div>
 
-            <div className="bg-white border border-[#DACDCA] rounded-xl shadow-sm overflow-hidden">
-                <div className="bg-[#42211D] h-24 relative">
-                    <div className="absolute -bottom-10 left-8">
-                        <div className="w-20 h-20 bg-white border border-[#DACDCA] rounded-full flex items-center justify-center shadow-md">
-                            <span className="text-[#42211D] text-2xl font-extrabold select-none">
-                                {profile.firstName ? profile.firstName.substring(0, 1).toUpperCase() : profile.username.substring(0, 1).toUpperCase()}
-                            </span>
+            <div className="bg-white border border-[#DACDCA] rounded-xl shadow-sm">
+                <div className="p-8 border-b border-[#DACDCA] mb-6">
+                    <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
+                        <div className="flex items-center gap-6">
+                            <div className={`w-20 h-20 rounded-full flex items-center justify-center shadow-md ${getRoleColor(userRole)}`}>
+                                {getRoleIcon(userRole)}
+                            </div>
+                            <div>
+                                <h2 className="text-2xl font-bold text-[#1A1A1A]">
+                                    {profile.firstName ? `${profile.firstName} ${profile.lastName}` : profile.username}
+                                </h2>
+                                <p className="text-[#7A7A7A] mt-1">Personal Account Details</p>
+                            </div>
                         </div>
-                    </div>
-                </div>
-
-                <div className="pt-14 pb-8 px-8">
-                    <div className="flex flex-col md:flex-row justify-between items-start md:items-center border-b border-[#DACDCA] pb-6 mb-6">
-                        <div>
-                            <h2 className="text-xl font-bold text-[#1A1A1A]">
-                                {profile.firstName ? `${profile.firstName} ${profile.lastName}` : profile.username}
-                            </h2>
-                            <p className="text-sm text-[#7A7A7A] mt-1">Personal Account Details</p>
-                        </div>
-                        <div className="mt-4 md:mt-0 flex items-center gap-3">
+                        <div className="flex items-center gap-3">
                             <span className="bg-[#F7F7F7] border border-[#DACDCA] text-[#42211D] font-bold text-xs uppercase tracking-wider px-3 py-1.5 rounded-full shadow-sm">
                                 {userRole}
                             </span>
                         </div>
                     </div>
+                </div>
+
+                <div className="px-8 pb-8">
 
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div className="bg-[#F7F7F7] border border-[#DACDCA] rounded-xl p-6">
@@ -206,12 +240,6 @@ export default function ProfilePage() {
                                         </svg>
                                         Active for notifications
                                     </span>
-                                </div>
-                                <div>
-                                    <label className="block text-xs font-semibold text-[#7A7A7A] mb-1">Account ID</label>
-                                    <p className="font-mono text-xs text-[#7A7A7A] bg-gray-100 p-2 rounded-lg border border-gray-200 overflow-x-auto select-all">
-                                        {profile.id}
-                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from "react";
+import { getUserProfile, updateUserProfile, type UserProfile } from "../api/userApi";
+
+export default function ProfilePage() {
+    const [profile, setProfile] = useState<UserProfile | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const [isEditing, setIsEditing] = useState(false);
+    const [editFirstName, setEditFirstName] = useState("");
+    const [editLastName, setEditLastName] = useState("");
+    const [saving, setSaving] = useState(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    useEffect(() => {
+        getUserProfile()
+            .then((data) => {
+                setProfile(data);
+                setLoading(false);
+            })
+            .catch((err) => {
+                console.error(err);
+                setError(err.message || "Failed to load profile details.");
+                loading && setLoading(false);
+            });
+    }, []);
+
+    const handleStartEdit = () => {
+        setEditFirstName(profile?.firstName || "");
+        setEditLastName(profile?.lastName || "");
+        setSaveError(null);
+        setIsEditing(true);
+    };
+
+    const handleCancel = () => {
+        setIsEditing(false);
+        setSaveError(null);
+    };
+
+    const handleSave = async () => {
+        if (!editFirstName.trim() || !editLastName.trim()) {
+            setSaveError("First Name and Last Name are required.");
+            return;
+        }
+
+        setSaving(true);
+        setSaveError(null);
+
+        try {
+            const updated = await updateUserProfile(editFirstName.trim(), editLastName.trim());
+            setProfile(updated);
+            setIsEditing(false);
+        } catch (err: any) {
+            console.error(err);
+            setSaveError(err.message || "Failed to update profile details.");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="p-6 max-w-7xl mx-auto text-[#1A1A1A]">
+                <div className="animate-pulse space-y-6">
+                    <div className="space-y-2">
+                        <div className="h-8 bg-[#F7F7F7] rounded w-1/4"></div>
+                        <div className="h-4 bg-[#F7F7F7] rounded w-1/3"></div>
+                    </div>
+                    <div className="bg-white border border-[#DACDCA] rounded-xl shadow-sm h-64"></div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error || !profile) {
+        return (
+            <div className="p-6 max-w-7xl mx-auto text-[#1A1A1A]">
+                <div className="bg-white border border-[#DACDCA] rounded-xl shadow-sm p-6 text-center">
+                    <p className="text-red-600 font-semibold mb-4">Error: {error || "Profile could not be found."}</p>
+                    <button
+                        onClick={() => window.location.reload()}
+                        className="bg-[#42211D] text-[#FFFFFF] font-bold py-2 px-4 rounded-lg hover:bg-[#2a1412] transition-colors"
+                    >
+                        Try Again
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    const userRole = profile.role || "GUEST";
+
+    const getRoleTitle = (role: string) => {
+        switch (role.toUpperCase()) {
+            case "ADMIN":
+                return "Admin Profile";
+            case "OWNER":
+                return "Owner Profile";
+            case "GUEST":
+            default:
+                return "Guest Profile";
+        }
+    };
+
+    const getRoleDescription = (role: string) => {
+        switch (role.toUpperCase()) {
+            case "ADMIN":
+                return "Manage system configuration and administrative accounts.";
+            case "OWNER":
+                return "Manage your property owner details and notification preferences.";
+            case "GUEST":
+            default:
+                return "Manage your guest account details and notification preferences.";
+        }
+    };
+
+    return (
+        <div className="p-6 max-w-7xl mx-auto text-[#1A1A1A]">
+            <div className="mb-8">
+                <h1 className="text-2xl font-bold text-[#1A1A1A]">{getRoleTitle(userRole)}</h1>
+                <p className="text-sm text-[#7A7A7A]">{getRoleDescription(userRole)}</p>
+            </div>
+
+            <div className="bg-white border border-[#DACDCA] rounded-xl shadow-sm overflow-hidden">
+                <div className="bg-[#42211D] h-24 relative">
+                    <div className="absolute -bottom-10 left-8">
+                        <div className="w-20 h-20 bg-white border border-[#DACDCA] rounded-full flex items-center justify-center shadow-md">
+                            <span className="text-[#42211D] text-2xl font-extrabold select-none">
+                                {profile.firstName ? profile.firstName.substring(0, 1).toUpperCase() : profile.username.substring(0, 1).toUpperCase()}
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="pt-14 pb-8 px-8">
+                    <div className="flex flex-col md:flex-row justify-between items-start md:items-center border-b border-[#DACDCA] pb-6 mb-6">
+                        <div>
+                            <h2 className="text-xl font-bold text-[#1A1A1A]">
+                                {profile.firstName ? `${profile.firstName} ${profile.lastName}` : profile.username}
+                            </h2>
+                            <p className="text-sm text-[#7A7A7A] mt-1">Personal Account Details</p>
+                        </div>
+                        <div className="mt-4 md:mt-0 flex items-center gap-3">
+                            <span className="bg-[#F7F7F7] border border-[#DACDCA] text-[#42211D] font-bold text-xs uppercase tracking-wider px-3 py-1.5 rounded-full shadow-sm">
+                                {userRole}
+                            </span>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        <div className="bg-[#F7F7F7] border border-[#DACDCA] rounded-xl p-6">
+                            <h3 className="text-sm font-bold text-[#7A7A7A] uppercase tracking-wider mb-4">Basic Information</h3>
+                            <div className="space-y-4">
+                                <div>
+                                    <label className="block text-xs font-semibold text-[#7A7A7A] mb-1">First Name</label>
+                                    {isEditing ? (
+                                        <input
+                                            type="text"
+                                            value={editFirstName}
+                                            onChange={(e) => setEditFirstName(e.target.value)}
+                                            className="w-full p-2 border border-[#DACDCA] rounded-lg focus:outline-none focus:ring-1 focus:ring-[#42211D] text-[#1A1A1A] font-semibold bg-white"
+                                            placeholder="Enter first name"
+                                            required
+                                        />
+                                    ) : (
+                                        <p className="font-semibold text-[#1A1A1A]">{profile.firstName || "—"}</p>
+                                    )}
+                                </div>
+                                <div>
+                                    <label className="block text-xs font-semibold text-[#7A7A7A] mb-1">Last Name</label>
+                                    {isEditing ? (
+                                        <input
+                                            type="text"
+                                            value={editLastName}
+                                            onChange={(e) => setEditLastName(e.target.value)}
+                                            className="w-full p-2 border border-[#DACDCA] rounded-lg focus:outline-none focus:ring-1 focus:ring-[#42211D] text-[#1A1A1A] font-semibold bg-white"
+                                            placeholder="Enter last name"
+                                            required
+                                        />
+                                    ) : (
+                                        <p className="font-semibold text-[#1A1A1A]">{profile.lastName || "—"}</p>
+                                    )}
+                                </div>
+                                <div>
+                                    <label className="block text-xs font-semibold text-[#7A7A7A] mb-1">Username</label>
+                                    <p className="font-semibold text-[#7A7A7A] bg-gray-100 p-2 rounded-lg border border-gray-200 select-none">
+                                        {profile.username}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="bg-[#F7F7F7] border border-[#DACDCA] rounded-xl p-6">
+                            <h3 className="text-sm font-bold text-[#7A7A7A] uppercase tracking-wider mb-4">Contact & Security</h3>
+                            <div className="space-y-4">
+                                <div>
+                                    <label className="block text-xs font-semibold text-[#7A7A7A] mb-1">Email Address</label>
+                                    <p className="font-semibold text-[#7A7A7A] bg-gray-100 p-2 rounded-lg border border-gray-200 select-none">
+                                        {profile.email}
+                                    </p>
+                                    <span className="inline-flex items-center gap-1.5 text-xs text-green-700 font-medium mt-2">
+                                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                        Active for notifications
+                                    </span>
+                                </div>
+                                <div>
+                                    <label className="block text-xs font-semibold text-[#7A7A7A] mb-1">Account ID</label>
+                                    <p className="font-mono text-xs text-[#7A7A7A] bg-gray-100 p-2 rounded-lg border border-gray-200 overflow-x-auto select-all">
+                                        {profile.id}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {saveError && (
+                        <div className="mt-6 bg-red-50 border border-red-200 rounded-lg p-3 text-red-700 text-sm font-semibold">
+                            {saveError}
+                        </div>
+                    )}
+
+                    <div className="mt-8 flex justify-end gap-4">
+                        {isEditing ? (
+                            <>
+                                <button
+                                    type="button"
+                                    onClick={handleCancel}
+                                    disabled={saving}
+                                    className="bg-[#F7F7F7] text-[#1A1A1A] border border-[#DACDCA] font-bold py-2.5 px-6 rounded-lg hover:bg-gray-100 transition-colors shadow-sm disabled:opacity-50"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleSave}
+                                    disabled={saving}
+                                    className="bg-[#42211D] text-[#FFFFFF] font-bold py-2.5 px-6 rounded-lg hover:bg-[#2a1412] transition-colors shadow-sm disabled:opacity-50 flex items-center gap-2"
+                                >
+                                    {saving ? "Saving..." : "Save Changes"}
+                                </button>
+                            </>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={handleStartEdit}
+                                className="bg-[#42211D] text-[#FFFFFF] font-bold py-2.5 px-6 rounded-lg hover:bg-[#2a1412] transition-colors shadow-sm"
+                            >
+                                Edit Profile
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/services/auth-service/pom.xml
+++ b/services/auth-service/pom.xml
@@ -128,9 +128,6 @@
                     <excludes>
                         <exclude>**/AuthServiceApplication.class</exclude>
                         <exclude>**/config/JpaConfig.class</exclude>
-                        <exclude>**/model/**/*.class</exclude>
-                        <exclude>**/dto/**/*.class</exclude>
-                        <exclude>**/mapper/**/*.class</exclude>
                         <exclude>**/config/OpenApiConfig.class</exclude>
                     </excludes>
                 </configuration>

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
@@ -26,7 +26,10 @@ public class SecurityConfig {
   @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthFilter jwtAuthFilter)
       throws Exception {
-    return http.csrf(csrf -> csrf.disable())
+    return http.csrf(
+            csrf ->
+                csrf.disable()) // NOSONAR: CSRF is disabled because the API is stateless and uses
+        // JWT tokens
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             auth ->

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
@@ -26,9 +26,7 @@ public class SecurityConfig {
   @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthFilter jwtAuthFilter)
       throws Exception {
-    return http.csrf(
-            csrf ->
-                csrf.disable())
+    return http.csrf(csrf -> csrf.disable())
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             auth ->

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
@@ -26,14 +26,13 @@ public class SecurityConfig {
   @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthFilter jwtAuthFilter)
       throws Exception {
-    return http.csrf(
-            csrf ->
-                csrf.disable()) // NOSONAR: CSRF is disabled because the API is stateless and uses
-        // JWT tokens
+    return http.csrf(csrf -> csrf.disable())
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/api/auth/**")
+                auth.requestMatchers("/api/auth/users/me")
+                    .authenticated()
+                    .requestMatchers("/api/auth/**")
                     .permitAll()
                     .requestMatchers(
                         "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**")

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/config/SecurityConfig.java
@@ -26,7 +26,9 @@ public class SecurityConfig {
   @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthFilter jwtAuthFilter)
       throws Exception {
-    return http.csrf(csrf -> csrf.disable())
+    return http.csrf(
+            csrf ->
+                csrf.disable())
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             auth ->

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/AuthController.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/AuthController.java
@@ -35,7 +35,12 @@ public class AuthController {
   @PostMapping("/register")
   public ResponseEntity<String> register(@Valid @RequestBody RegisterRequest request) {
     userService.register(
-        request.getUsername(), request.getEmail(), request.getRole(), request.getPassword());
+        request.getUsername(),
+        request.getEmail(),
+        request.getRole(),
+        request.getPassword(),
+        request.getFirstName(),
+        request.getLastName());
     return ResponseEntity.ok("User registered");
   }
 

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileController.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileController.java
@@ -1,17 +1,21 @@
 package io.github.kwatera_project.kwatera.auth_service.controller;
 
 import io.github.kwatera_project.kwatera.auth_service.dto.UserProfileDto;
+import io.github.kwatera_project.kwatera.auth_service.dto.UserProfileUpdateDto;
 import io.github.kwatera_project.kwatera.auth_service.mapper.UserMapper;
 import io.github.kwatera_project.kwatera.auth_service.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/user")
+@RequestMapping("/api/auth/users")
 @RequiredArgsConstructor
 public class UserProfileController {
 
@@ -20,9 +24,17 @@ public class UserProfileController {
 
   @GetMapping("/me")
   public ResponseEntity<UserProfileDto> getUserProfile(final Authentication authentication) {
-
     final var user = userService.getUserByEmail(authentication.getName());
+    return ResponseEntity.ok(userMapper.toUserProfileDto(user));
+  }
 
+  @PutMapping("/me")
+  public ResponseEntity<UserProfileDto> updateUserProfile(
+      final Authentication authentication,
+      @Valid @RequestBody final UserProfileUpdateDto request) {
+    final var user =
+        userService.updateProfile(
+            authentication.getName(), request.firstName(), request.lastName());
     return ResponseEntity.ok(userMapper.toUserProfileDto(user));
   }
 }

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileController.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileController.java
@@ -30,8 +30,7 @@ public class UserProfileController {
 
   @PutMapping("/me")
   public ResponseEntity<UserProfileDto> updateUserProfile(
-      final Authentication authentication,
-      @Valid @RequestBody final UserProfileUpdateDto request) {
+      final Authentication authentication, @Valid @RequestBody final UserProfileUpdateDto request) {
     final var user =
         userService.updateProfile(
             authentication.getName(), request.firstName(), request.lastName());

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/RegisterRequest.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/RegisterRequest.java
@@ -17,4 +17,8 @@ public class RegisterRequest {
   @NotNull private Role role;
 
   @NotBlank private String password;
+
+  @NotBlank private String firstName;
+
+  @NotBlank private String lastName;
 }

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileDto.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileDto.java
@@ -1,3 +1,7 @@
 package io.github.kwatera_project.kwatera.auth_service.dto;
 
-public record UserProfileDto(String email, String username) {}
+import io.github.kwatera_project.kwatera.auth_service.model.Role;
+import java.util.UUID;
+
+public record UserProfileDto(
+    UUID id, String username, String firstName, String lastName, String email, Role role) {}

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileDto.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileDto.java
@@ -1,7 +1,6 @@
 package io.github.kwatera_project.kwatera.auth_service.dto;
 
 import io.github.kwatera_project.kwatera.auth_service.model.Role;
-import java.util.UUID;
 
 public record UserProfileDto(
-    UUID id, String username, String firstName, String lastName, String email, Role role) {}
+    String username, String firstName, String lastName, String email, Role role) {}

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileUpdateDto.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileUpdateDto.java
@@ -2,7 +2,4 @@ package io.github.kwatera_project.kwatera.auth_service.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record UserProfileUpdateDto(
-    @NotBlank String firstName,
-    @NotBlank String lastName
-) {}
+public record UserProfileUpdateDto(@NotBlank String firstName, @NotBlank String lastName) {}

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileUpdateDto.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileUpdateDto.java
@@ -1,0 +1,8 @@
+package io.github.kwatera_project.kwatera.auth_service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserProfileUpdateDto(
+    @NotBlank String firstName,
+    @NotBlank String lastName
+) {}

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapper.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapper.java
@@ -7,6 +7,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserMapper {
   public UserProfileDto toUserProfileDto(final User user) {
-    return new UserProfileDto(user.getEmail(), user.getUsername());
+    return new UserProfileDto(
+        user.getId(),
+        user.getUsername(),
+        user.getFirstName(),
+        user.getLastName(),
+        user.getEmail(),
+        user.getRole());
   }
 }

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapper.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapper.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 public class UserMapper {
   public UserProfileDto toUserProfileDto(final User user) {
     return new UserProfileDto(
-        user.getId(),
         user.getUsername(),
         user.getFirstName(),
         user.getLastName(),

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/model/User.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/model/User.java
@@ -15,21 +15,19 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-@Entity // Mapping to a table in the DB.
+@Entity
 @Table(name = "users")
 @Getter
 @Setter
 @NoArgsConstructor
-@EntityListeners(
-    AuditingEntityListener.class) // Enables auto-completion of createdAt, updatedAt fields.
+@EntityListeners(AuditingEntityListener.class)
 public class User implements UserDetails {
-  /// A class representing the user table in the database.
-  @Id // Master key.
-  @GeneratedValue(strategy = GenerationType.UUID) // Automatically generates UUID.
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
   @Column(nullable = false)
-  @Enumerated(EnumType.STRING) // Saved in the database as text.
+  @Enumerated(EnumType.STRING)
   private Role role;
 
   @Column(nullable = false, unique = true)
@@ -38,16 +36,21 @@ public class User implements UserDetails {
   @Column(nullable = false, unique = true)
   private String email;
 
+  @Column(name = "first_name")
+  private String firstName;
+
+  @Column(name = "last_name")
+  private String lastName;
+
   @Column(nullable = false)
   private String password;
 
   @Column(name = "created_at", nullable = false, updatable = false)
-  @CreatedDate // The field is set automatically when the record is created and cannot be changed
-  // later.
+  @CreatedDate
   private Instant createdAt;
 
   @Column(name = "updated_at")
-  @LastModifiedDate // Field updated automatically whenever a record changes.
+  @LastModifiedDate
   private Instant updatedAt;
 
   @Override

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/service/UserService.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/service/UserService.java
@@ -25,7 +25,13 @@ public class UserService {
                     HttpStatus.NOT_FOUND, "The user account has been deleted or inactivated"));
   }
 
-  public void register(String username, String email, Role role, String password, String firstName, String lastName) {
+  public void register(
+      String username,
+      String email,
+      Role role,
+      String password,
+      String firstName,
+      String lastName) {
     if (userRepository.findByUsername(username).isPresent()) {
       throw new ResponseStatusException(HttpStatus.CONFLICT, "User already exists");
     }

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/service/UserService.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService {
                     HttpStatus.NOT_FOUND, "The user account has been deleted or inactivated"));
   }
 
-  public void register(String username, String email, Role role, String password) {
+  public void register(String username, String email, Role role, String password, String firstName, String lastName) {
     if (userRepository.findByUsername(username).isPresent()) {
       throw new ResponseStatusException(HttpStatus.CONFLICT, "User already exists");
     }
@@ -34,6 +34,8 @@ public class UserService {
     user.setUsername(username);
     user.setEmail(email);
     user.setPassword(passwordEncoder.encode(password));
+    user.setFirstName(firstName);
+    user.setLastName(lastName);
 
     if (role == null) {
       user.setRole(Role.GUEST);
@@ -44,5 +46,12 @@ public class UserService {
     }
 
     userRepository.save(user);
+  }
+
+  public User updateProfile(String email, String firstName, String lastName) {
+    User user = getUserByEmail(email);
+    user.setFirstName(firstName);
+    user.setLastName(lastName);
+    return userRepository.save(user);
   }
 }

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/AuthControllerTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/AuthControllerTest.java
@@ -59,6 +59,8 @@ class AuthControllerTest {
     request.setEmail("jan@test.com");
     request.setPassword("123");
     request.setRole(Role.GUEST);
+    request.setFirstName("Jan");
+    request.setLastName("Kowalski");
 
     mockMvc
         .perform(
@@ -68,7 +70,7 @@ class AuthControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().string("User registered"));
 
-    verify(userService).register("jan", "jan@test.com", Role.GUEST, "123");
+    verify(userService).register("jan", "jan@test.com", Role.GUEST, "123", "Jan", "Kowalski");
   }
 
   @Test
@@ -78,10 +80,12 @@ class AuthControllerTest {
     request.setEmail("jan@test.com");
     request.setPassword("123");
     request.setRole(Role.GUEST);
+    request.setFirstName("Jan");
+    request.setLastName("Kowalski");
 
     doThrow(new ResponseStatusException(CONFLICT, "User already exists"))
         .when(userService)
-        .register("jan", "jan@test.com", Role.GUEST, "123");
+        .register("jan", "jan@test.com", Role.GUEST, "123", "Jan", "Kowalski");
 
     mockMvc
         .perform(
@@ -108,6 +112,8 @@ class AuthControllerTest {
     request.setEmail("test@test.com");
     request.setPassword("123456");
     request.setRole(Role.GUEST);
+    request.setFirstName("Jan");
+    request.setLastName("Kowalski");
 
     mockMvc
         .perform(
@@ -116,7 +122,7 @@ class AuthControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
 
-    verify(userService, never()).register(any(), any(), any(), any());
+    verify(userService, never()).register(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -126,6 +132,8 @@ class AuthControllerTest {
     request.setEmail("not-email");
     request.setPassword("123456");
     request.setRole(Role.GUEST);
+    request.setFirstName("Jan");
+    request.setLastName("Kowalski");
 
     mockMvc
         .perform(
@@ -142,6 +150,8 @@ class AuthControllerTest {
     request.setEmail("test@test.com");
     request.setPassword("123456");
     request.setRole(null);
+    request.setFirstName("Jan");
+    request.setLastName("Kowalski");
 
     mockMvc
         .perform(

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
@@ -100,7 +100,8 @@ class UserProfileControllerTest {
     // When + Then
     mockMvc
         .perform(
-            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put("/api/auth/users/me")
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put(
+                    "/api/auth/users/me")
                 .with(user(email).roles("GUEST"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"firstName\":\"NewFirst\",\"lastName\":\"NewLast\"}")

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
@@ -43,13 +43,17 @@ class UserProfileControllerTest {
     // Given
     String email = "test@mail.com";
     String username = "test";
+    java.util.UUID id = java.util.UUID.randomUUID();
 
     User user = new User();
+    user.setId(id);
     user.setUsername(username);
     user.setEmail(email);
+    user.setFirstName("First");
+    user.setLastName("Last");
     user.setRole(Role.GUEST);
 
-    UserProfileDto dto = new UserProfileDto(email, username);
+    UserProfileDto dto = new UserProfileDto(id, username, "First", "Last", email, Role.GUEST);
 
     when(userService.getUserByEmail(email)).thenReturn(user);
     when(userMapper.toUserProfileDto(user)).thenReturn(dto);
@@ -57,12 +61,60 @@ class UserProfileControllerTest {
     // When + Then
     mockMvc
         .perform(
-            get("/api/user/me").with(user(email).roles("GUEST")).accept(MediaType.APPLICATION_JSON))
+            get("/api/auth/users/me")
+                .with(user(email).roles("GUEST"))
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.email").value(email));
+        .andExpect(jsonPath("$.id").value(id.toString()))
+        .andExpect(jsonPath("$.username").value(username))
+        .andExpect(jsonPath("$.firstName").value("First"))
+        .andExpect(jsonPath("$.lastName").value("Last"))
+        .andExpect(jsonPath("$.email").value(email))
+        .andExpect(jsonPath("$.role").value("GUEST"));
 
     verify(userService).getUserByEmail(email);
     verify(userMapper).toUserProfileDto(user);
+  }
+
+  @Test
+  void shouldUpdateUserProfile() throws Exception {
+    // Given
+    String email = "test@mail.com";
+    String username = "test";
+    java.util.UUID id = java.util.UUID.randomUUID();
+
+    User updatedUser = new User();
+    updatedUser.setId(id);
+    updatedUser.setUsername(username);
+    updatedUser.setEmail(email);
+    updatedUser.setFirstName("NewFirst");
+    updatedUser.setLastName("NewLast");
+    updatedUser.setRole(Role.GUEST);
+
+    UserProfileDto dto = new UserProfileDto(id, username, "NewFirst", "NewLast", email, Role.GUEST);
+
+    when(userService.updateProfile(email, "NewFirst", "NewLast")).thenReturn(updatedUser);
+    when(userMapper.toUserProfileDto(updatedUser)).thenReturn(dto);
+
+    // When + Then
+    mockMvc
+        .perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put("/api/auth/users/me")
+                .with(user(email).roles("GUEST"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"firstName\":\"NewFirst\",\"lastName\":\"NewLast\"}")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value(id.toString()))
+        .andExpect(jsonPath("$.username").value(username))
+        .andExpect(jsonPath("$.firstName").value("NewFirst"))
+        .andExpect(jsonPath("$.lastName").value("NewLast"))
+        .andExpect(jsonPath("$.email").value(email))
+        .andExpect(jsonPath("$.role").value("GUEST"));
+
+    verify(userService).updateProfile(email, "NewFirst", "NewLast");
+    verify(userMapper).toUserProfileDto(updatedUser);
   }
 }

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
@@ -121,7 +121,7 @@ class UserProfileControllerTest {
   void shouldRejectUnauthenticatedGetUserProfile() throws Exception {
     mockMvc
         .perform(get("/api/auth/users/me").accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isUnauthorized());
+        .andExpect(status().isForbidden());
   }
 
   @Test
@@ -133,6 +133,6 @@ class UserProfileControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"firstName\":\"NewFirst\",\"lastName\":\"NewLast\"}")
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isUnauthorized());
+        .andExpect(status().isForbidden());
   }
 }

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
@@ -53,7 +53,7 @@ class UserProfileControllerTest {
     user.setLastName("Last");
     user.setRole(Role.GUEST);
 
-    UserProfileDto dto = new UserProfileDto(id, username, "First", "Last", email, Role.GUEST);
+    UserProfileDto dto = new UserProfileDto(username, "First", "Last", email, Role.GUEST);
 
     when(userService.getUserByEmail(email)).thenReturn(user);
     when(userMapper.toUserProfileDto(user)).thenReturn(dto);
@@ -66,7 +66,6 @@ class UserProfileControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(id.toString()))
         .andExpect(jsonPath("$.username").value(username))
         .andExpect(jsonPath("$.firstName").value("First"))
         .andExpect(jsonPath("$.lastName").value("Last"))
@@ -92,7 +91,7 @@ class UserProfileControllerTest {
     updatedUser.setLastName("NewLast");
     updatedUser.setRole(Role.GUEST);
 
-    UserProfileDto dto = new UserProfileDto(id, username, "NewFirst", "NewLast", email, Role.GUEST);
+    UserProfileDto dto = new UserProfileDto(username, "NewFirst", "NewLast", email, Role.GUEST);
 
     when(userService.updateProfile(email, "NewFirst", "NewLast")).thenReturn(updatedUser);
     when(userMapper.toUserProfileDto(updatedUser)).thenReturn(dto);
@@ -108,7 +107,6 @@ class UserProfileControllerTest {
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(id.toString()))
         .andExpect(jsonPath("$.username").value(username))
         .andExpect(jsonPath("$.firstName").value("NewFirst"))
         .andExpect(jsonPath("$.lastName").value("NewLast"))
@@ -117,5 +115,24 @@ class UserProfileControllerTest {
 
     verify(userService).updateProfile(email, "NewFirst", "NewLast");
     verify(userMapper).toUserProfileDto(updatedUser);
+  }
+
+  @Test
+  void shouldRejectUnauthenticatedGetUserProfile() throws Exception {
+    mockMvc
+        .perform(get("/api/auth/users/me").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void shouldRejectUnauthenticatedUpdateUserProfile() throws Exception {
+    mockMvc
+        .perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put(
+                    "/api/auth/users/me")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"firstName\":\"NewFirst\",\"lastName\":\"NewLast\"}")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
   }
 }

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
@@ -29,4 +29,22 @@ class DtoTest {
     assertThat(dto.firstName()).isEqualTo("John");
     assertThat(dto.lastName()).isEqualTo("Doe");
   }
+
+  @Test
+  void testRegisterRequest() {
+    RegisterRequest request = new RegisterRequest();
+    request.setUsername("john");
+    request.setEmail("john@example.com");
+    request.setRole(Role.OWNER);
+    request.setPassword("pass");
+    request.setFirstName("John");
+    request.setLastName("Doe");
+
+    assertThat(request.getUsername()).isEqualTo("john");
+    assertThat(request.getEmail()).isEqualTo("john@example.com");
+    assertThat(request.getRole()).isEqualTo(Role.OWNER);
+    assertThat(request.getPassword()).isEqualTo("pass");
+    assertThat(request.getFirstName()).isEqualTo("John");
+    assertThat(request.getLastName()).isEqualTo("Doe");
+  }
 }

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
@@ -3,18 +3,15 @@ package io.github.kwatera_project.kwatera.auth_service.dto;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.kwatera_project.kwatera.auth_service.model.Role;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class DtoTest {
 
   @Test
   void testUserProfileDto() {
-    UUID id = UUID.randomUUID();
     UserProfileDto dto =
-        new UserProfileDto(id, "username", "John", "Doe", "john@example.com", Role.GUEST);
+        new UserProfileDto("username", "John", "Doe", "john@example.com", Role.GUEST);
 
-    assertThat(dto.id()).isEqualTo(id);
     assertThat(dto.username()).isEqualTo("username");
     assertThat(dto.firstName()).isEqualTo("John");
     assertThat(dto.lastName()).isEqualTo("Doe");

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
@@ -1,0 +1,32 @@
+package io.github.kwatera_project.kwatera.auth_service.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.kwatera_project.kwatera.auth_service.model.Role;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class DtoTest {
+
+  @Test
+  void testUserProfileDto() {
+    UUID id = UUID.randomUUID();
+    UserProfileDto dto =
+        new UserProfileDto(id, "username", "John", "Doe", "john@example.com", Role.GUEST);
+
+    assertThat(dto.id()).isEqualTo(id);
+    assertThat(dto.username()).isEqualTo("username");
+    assertThat(dto.firstName()).isEqualTo("John");
+    assertThat(dto.lastName()).isEqualTo("Doe");
+    assertThat(dto.email()).isEqualTo("john@example.com");
+    assertThat(dto.role()).isEqualTo(Role.GUEST);
+  }
+
+  @Test
+  void testUserProfileUpdateDto() {
+    UserProfileUpdateDto dto = new UserProfileUpdateDto("John", "Doe");
+
+    assertThat(dto.firstName()).isEqualTo("John");
+    assertThat(dto.lastName()).isEqualTo("Doe");
+  }
+}

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapperTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapperTest.java
@@ -1,0 +1,36 @@
+package io.github.kwatera_project.kwatera.auth_service.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.kwatera_project.kwatera.auth_service.dto.UserProfileDto;
+import io.github.kwatera_project.kwatera.auth_service.model.Role;
+import io.github.kwatera_project.kwatera.auth_service.model.User;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UserMapperTest {
+
+  private final UserMapper userMapper = new UserMapper();
+
+  @Test
+  void shouldMapUserToUserProfileDto() {
+    UUID id = UUID.randomUUID();
+    User user = new User();
+    user.setId(id);
+    user.setUsername("john");
+    user.setEmail("john@example.com");
+    user.setFirstName("John");
+    user.setLastName("Doe");
+    user.setRole(Role.GUEST);
+
+    UserProfileDto dto = userMapper.toUserProfileDto(user);
+
+    assertThat(dto).isNotNull();
+    assertThat(dto.id()).isEqualTo(id);
+    assertThat(dto.username()).isEqualTo("john");
+    assertThat(dto.firstName()).isEqualTo("John");
+    assertThat(dto.lastName()).isEqualTo("Doe");
+    assertThat(dto.email()).isEqualTo("john@example.com");
+    assertThat(dto.role()).isEqualTo(Role.GUEST);
+  }
+}

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapperTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapperTest.java
@@ -26,7 +26,6 @@ class UserMapperTest {
     UserProfileDto dto = userMapper.toUserProfileDto(user);
 
     assertThat(dto).isNotNull();
-    assertThat(dto.id()).isEqualTo(id);
     assertThat(dto.username()).isEqualTo("john");
     assertThat(dto.firstName()).isEqualTo("John");
     assertThat(dto.lastName()).isEqualTo("Doe");

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/model/UserTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/model/UserTest.java
@@ -1,0 +1,50 @@
+package io.github.kwatera_project.kwatera.auth_service.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+  @Test
+  void testUserDetailsMethods() {
+    User user = new User();
+    user.setRole(Role.GUEST);
+
+    assertThat(user.getAuthorities()).hasSize(1);
+    assertThat(user.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_GUEST");
+    assertThat(user.isAccountNonExpired()).isTrue();
+    assertThat(user.isAccountNonLocked()).isTrue();
+    assertThat(user.isCredentialsNonExpired()).isTrue();
+    assertThat(user.isEnabled()).isTrue();
+  }
+
+  @Test
+  void testGettersAndSetters() {
+    UUID id = UUID.randomUUID();
+    Instant now = Instant.now();
+    User user = new User();
+
+    user.setId(id);
+    user.setUsername("john");
+    user.setEmail("john@example.com");
+    user.setFirstName("John");
+    user.setLastName("Doe");
+    user.setPassword("pass");
+    user.setRole(Role.OWNER);
+    user.setCreatedAt(now);
+    user.setUpdatedAt(now);
+
+    assertThat(user.getId()).isEqualTo(id);
+    assertThat(user.getUsername()).isEqualTo("john");
+    assertThat(user.getEmail()).isEqualTo("john@example.com");
+    assertThat(user.getFirstName()).isEqualTo("John");
+    assertThat(user.getLastName()).isEqualTo("Doe");
+    assertThat(user.getPassword()).isEqualTo("pass");
+    assertThat(user.getRole()).isEqualTo(Role.OWNER);
+    assertThat(user.getCreatedAt()).isEqualTo(now);
+    assertThat(user.getUpdatedAt()).isEqualTo(now);
+  }
+}

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/service/UserServiceTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/service/UserServiceTest.java
@@ -58,7 +58,7 @@ class UserServiceTest {
 
     when(passwordEncoder.encode("pass")).thenReturn("encoded-pass");
 
-    userService.register("john", "john@mail.com", Role.OWNER, "pass");
+    userService.register("john", "john@mail.com", Role.OWNER, "pass", "John", "Doe");
 
     ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
     verify(userRepository).save(captor.capture());
@@ -69,6 +69,8 @@ class UserServiceTest {
     assertThat(saved.getEmail()).isEqualTo("john@mail.com");
     assertThat(saved.getPassword()).isEqualTo("encoded-pass");
     assertThat(saved.getRole()).isEqualTo(Role.OWNER);
+    assertThat(saved.getFirstName()).isEqualTo("John");
+    assertThat(saved.getLastName()).isEqualTo("Doe");
   }
 
   @Test
@@ -77,19 +79,21 @@ class UserServiceTest {
 
     when(passwordEncoder.encode(any())).thenReturn("encoded");
 
-    userService.register("john", "john@mail.com", null, "pass");
+    userService.register("john", "john@mail.com", null, "pass", "John", "Doe");
 
     ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
     verify(userRepository).save(captor.capture());
 
     assertThat(captor.getValue().getRole()).isEqualTo(Role.GUEST);
+    assertThat(captor.getValue().getFirstName()).isEqualTo("John");
+    assertThat(captor.getValue().getLastName()).isEqualTo("Doe");
   }
 
   @Test
   void shouldThrow409WhenUsernameExists() {
     when(userRepository.findByUsername("john")).thenReturn(Optional.of(new User()));
 
-    assertThatThrownBy(() -> userService.register("john", "john@mail.com", Role.GUEST, "pass"))
+    assertThatThrownBy(() -> userService.register("john", "john@mail.com", Role.GUEST, "pass", "John", "Doe"))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex -> {
@@ -104,7 +108,7 @@ class UserServiceTest {
   void shouldRejectAdminRole() {
     when(userRepository.findByUsername("john")).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> userService.register("john", "john@mail.com", Role.ADMIN, "pass"))
+    assertThatThrownBy(() -> userService.register("john", "john@mail.com", Role.ADMIN, "pass", "John", "Doe"))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex -> {
@@ -113,5 +117,23 @@ class UserServiceTest {
             });
 
     verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void shouldUpdateUserProfileSuccessfully() {
+    User user = new User();
+    user.setEmail("john@mail.com");
+    user.setFirstName("OldFirst");
+    user.setLastName("OldLast");
+
+    when(userRepository.findByEmail("john@mail.com")).thenReturn(Optional.of(user));
+    when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    User updated = userService.updateProfile("john@mail.com", "NewFirst", "NewLast");
+
+    assertThat(updated.getFirstName()).isEqualTo("NewFirst");
+    assertThat(updated.getLastName()).isEqualTo("NewLast");
+    verify(userRepository).findByEmail("john@mail.com");
+    verify(userRepository).save(user);
   }
 }

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/service/UserServiceTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/service/UserServiceTest.java
@@ -93,7 +93,8 @@ class UserServiceTest {
   void shouldThrow409WhenUsernameExists() {
     when(userRepository.findByUsername("john")).thenReturn(Optional.of(new User()));
 
-    assertThatThrownBy(() -> userService.register("john", "john@mail.com", Role.GUEST, "pass", "John", "Doe"))
+    assertThatThrownBy(
+            () -> userService.register("john", "john@mail.com", Role.GUEST, "pass", "John", "Doe"))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex -> {
@@ -108,7 +109,8 @@ class UserServiceTest {
   void shouldRejectAdminRole() {
     when(userRepository.findByUsername("john")).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> userService.register("john", "john@mail.com", Role.ADMIN, "pass", "John", "Doe"))
+    assertThatThrownBy(
+            () -> userService.register("john", "john@mail.com", Role.ADMIN, "pass", "John", "Doe"))
         .isInstanceOf(ResponseStatusException.class)
         .satisfies(
             ex -> {

--- a/services/db-migrations/src/main/resources/db/migration/V10__add_first_name_and_last_name_to_users.sql
+++ b/services/db-migrations/src/main/resources/db/migration/V10__add_first_name_and_last_name_to_users.sql
@@ -1,0 +1,9 @@
+ALTER TABLE users ADD COLUMN first_name VARCHAR(100);
+ALTER TABLE users ADD COLUMN last_name VARCHAR(100);
+
+-- Update existing demo data to have valid first and last names
+UPDATE users SET first_name = 'Admin', last_name = 'User' WHERE username = 'admin';
+UPDATE users SET first_name = 'John', last_name = 'Owner' WHERE username = 'owner1';
+UPDATE users SET first_name = 'Jane', last_name = 'Owner' WHERE username = 'owner2';
+UPDATE users SET first_name = 'Bob', last_name = 'Guest' WHERE username = 'guest1';
+UPDATE users SET first_name = 'Alice', last_name = 'Guest' WHERE username = 'guest2';


### PR DESCRIPTION
## Summary
Introduce user profile support across frontend and auth service.


## Linked issue
Closes #71 


## Scope of changes
- Backend: add firstName/lastName to User model, persist columns, and add DB migration V10. Update RegisterRequest to require names and UserService.register signature to accept and save them. Add updateProfile service, new UserProfileUpdateDto, and a PUT /api/auth/users/me endpoint in UserProfileController. Update UserMapper and UserProfileDto to include id, names and role. Tighten security to require authentication for /api/auth/users/me.

- Frontend: add ProfilePage with edit/save flows, userApi with getUserProfile/updateUserProfile, expose /profile route and navbar link, and include first/last name inputs on registration form.

- Tests: update and extend unit tests to cover registration changes and profile retrieval/updating.


## Testing status
- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable
- [ ] Not applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [ ] Documentation updated if needed
- [ ] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
- [x] Ready for review