### PR TITLE
Add tests for getAllUnitIds

### DIFF
--- a/services/property-service/src/test/java/io/github/kwatera_project/kwatera/property_service/controller/PropertyControllerTest.java
+++ b/services/property-service/src/test/java/io/github/kwatera_project/kwatera/property_service/controller/PropertyControllerTest.java
@@ -93,4 +93,16 @@ class PropertyControllerTest {
     assertEquals(2, result.size());
     assertEquals("img1.jpg", result.get(0));
   }
+
+  @Test
+  void getAllUnitIds_shouldReturnUnitIds() {
+    UUID unitId = UUID.randomUUID();
+
+    when(service.getAllUnitIds()).thenReturn(List.of(unitId));
+
+    var result = controller.getAllUnitIds();
+
+    assertEquals(1, result.size());
+    assertEquals(unitId, result.get(0));
+  }
 }

--- a/services/property-service/src/test/java/io/github/kwatera_project/kwatera/property_service/service/PropertyServiceTest.java
+++ b/services/property-service/src/test/java/io/github/kwatera_project/kwatera/property_service/service/PropertyServiceTest.java
@@ -181,4 +181,17 @@ class PropertyServiceTest {
     assertEquals(1, result.size());
     assertEquals("img1.jpg", result.get(0));
   }
+
+  @Test
+  void getAllUnitIds_shouldReturnUnitIds() {
+    Unit unit = new Unit();
+    unit.setId(UUID.randomUUID());
+
+    when(unitRepository.findAll()).thenReturn(List.of(unit));
+
+    var result = propertyService.getAllUnitIds();
+
+    assertEquals(1, result.size());
+    assertEquals(unit.getId(), result.get(0));
+  }
 }


### PR DESCRIPTION
## Summary

Add missing unit test coverage for `getAllUnitIds` in `property-service`.

This PR adds tests for both the controller and service layer:
- `PropertyControllerTest` verifies that `getAllUnitIds()` delegates to the service and returns the expected unit id list.
- `PropertyServiceTest` verifies that `getAllUnitIds()` reads all units from `unitRepository.findAll()` and maps them to unit ids.

## Linked issue

Closes #90

## Scope of changes

- Added unit test for `PropertyController.getAllUnitIds()`.
- Added unit test for `PropertyService.getAllUnitIds()`.
- No production code changes were introduced.

## Testing status

Describe how this was verified.

- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass

## Checklist

- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
- [x] Ready for review