### PR TITLE
Add media_readings table

### DIFF
--- a/services/billing-service/pom.xml
+++ b/services/billing-service/pom.xml
@@ -22,6 +22,18 @@
         </sonar.coverage.exclusions>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.21.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -113,6 +125,26 @@
         <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.21.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.21.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/MediaReading.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/MediaReading.java
@@ -1,0 +1,93 @@
+package io.github.kwatera_project.kwatera.billing_service.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Check;
+import org.hibernate.annotations.Generated;
+import org.hibernate.generator.EventType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@Check(constraints = "final_reading >= initial_reading")
+@Table(name = "media_readings")
+public class MediaReading {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  @Column(name = "settlement_item_id", nullable = false)
+  private UUID settlementItemId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "utility_type", nullable = false, length = 50)
+  private UtilityType utilityType;
+
+  @NotNull
+  @Column(name = "initial_reading", precision = 12, scale = 6, nullable = false)
+  @DecimalMin(value = "0.0")
+  private BigDecimal initialReading;
+
+  @Column(name = "initial_confidence_score", precision = 12, scale = 6, nullable = false)
+  private BigDecimal initialConfidenceScore;
+
+  @Column(name = "final_reading", precision = 12, scale = 6)
+  @DecimalMin(value = "0.0")
+  private BigDecimal finalReading;
+
+  @Column(name = "final_confidence_score", precision = 12, scale = 6)
+  private BigDecimal finalConfidenceScore;
+
+  @Generated(event = EventType.INSERT)
+  @Column(
+      name = "consumption_difference",
+      precision = 12,
+      scale = 6,
+      insertable = false,
+      updatable = false,
+      columnDefinition =
+          "numeric(12,6) GENERATED ALWAYS AS (final_reading - initial_reading) STORED")
+  private BigDecimal consumptionDifference;
+
+  @NotNull
+  @Column(name = "unit_price", nullable = false, precision = 12, scale = 2)
+  @DecimalMin(value = "0.0")
+  private BigDecimal unitPrice;
+
+  @Generated(event = EventType.INSERT)
+  @Column(
+      name = "calculated_cost",
+      precision = 12,
+      scale = 2,
+      insertable = false,
+      updatable = false,
+      columnDefinition =
+          "numeric(12,2) GENERATED ALWAYS AS ((final_reading - initial_reading) * unit_price) STORED")
+  private BigDecimal calculatedCost; // GENERATED ALWAYS AS (...) STORED
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "reading_source", nullable = false, length = 50)
+  private ReadingSource readingSource = ReadingSource.OCR;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "reading_status", nullable = false, length = 50)
+  private ReadingStatus readingStatus = ReadingStatus.PENDING;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CreatedDate
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  @LastModifiedDate
+  private Instant updatedAt;
+}

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/MediaReading.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/MediaReading.java
@@ -26,8 +26,8 @@ public class MediaReading {
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  @Column(name = "settlement_item_id", nullable = false)
-  private UUID settlementItemId;
+  @Column(name = "settlement_id", nullable = false)
+  private UUID settlementId;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "utility_type", nullable = false, length = 50)

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/ReadingSource.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/ReadingSource.java
@@ -1,0 +1,6 @@
+package io.github.kwatera_project.kwatera.billing_service.model;
+
+public enum ReadingSource {
+  MANUAL,
+  OCR
+}

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/ReadingStatus.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/ReadingStatus.java
@@ -1,0 +1,9 @@
+package io.github.kwatera_project.kwatera.billing_service.model;
+
+public enum ReadingStatus {
+  PENDING,
+  AUTO_APPROVED,
+  REQUEST_REUPLOAD,
+  REQUEST_MANUAL_REVIEW,
+  MANUALLY_APPROVED
+}

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/UtilityType.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/model/UtilityType.java
@@ -1,0 +1,6 @@
+package io.github.kwatera_project.kwatera.billing_service.model;
+
+public enum UtilityType {
+  ELECTRICITY,
+  WATER
+}

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepository.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepository.java
@@ -1,6 +1,7 @@
 package io.github.kwatera_project.kwatera.billing_service.repository;
 
 import io.github.kwatera_project.kwatera.billing_service.model.MediaReading;
+import io.github.kwatera_project.kwatera.billing_service.model.UtilityType;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MediaReadingRepository extends JpaRepository<MediaReading, UUID> {
   Optional<MediaReading> findBySettlementId(UUID settlementId);
+
+  Optional<MediaReading> findBySettlementIdAndUtilityType(
+      UUID reservationId, UtilityType utilityType);
 }

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepository.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepository.java
@@ -1,0 +1,12 @@
+package io.github.kwatera_project.kwatera.billing_service.repository;
+
+import io.github.kwatera_project.kwatera.billing_service.model.MediaReading;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MediaReadingRepository extends JpaRepository<MediaReading, UUID> {
+  Optional<MediaReading> findBySettlementItemId(UUID settlementItemId);
+}

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepository.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MediaReadingRepository extends JpaRepository<MediaReading, UUID> {
-  Optional<MediaReading> findBySettlementItemId(UUID settlementItemId);
+  Optional<MediaReading> findBySettlementId(UUID settlementId);
 }

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
@@ -78,17 +78,17 @@ public class MediaReadingService {
     mediaReadingRepository.save(reading);
 
     UtilityType utilityType = reading.getUtilityType();
-    BigDecimal unit_price = reading.getUnitPrice();
-    BigDecimal consumption_difference = reading.getConsumptionDifference();
+    BigDecimal unitPrice = reading.getUnitPrice();
+    BigDecimal consumptionDifference = finalReading.subtract(reading.getInitialReading());
 
-    // Tworzy się jeszcze nie opłacone SelletentItem -> dla klienta powinien się pojawić przycisk
+    // Tworzy się jeszcze nie opłacone SettlementItem -> dla klienta powinien się pojawić przycisk
     settlementService.addUtilitySettlementItem(
-        settlementId,
-        unitId,
-        mapUtilityType(utilityType),
-        descriptionFor(utilityType),
-        consumption_difference,
-        unit_price);
+            settlementId,
+            unitId,
+            mapUtilityType(utilityType),
+            descriptionFor(utilityType),
+            consumptionDifference,
+            unitPrice);
   }
 
   private SettlementItemType mapUtilityType(UtilityType utilityType) {

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
@@ -83,12 +83,12 @@ public class MediaReadingService {
 
     // Tworzy się jeszcze nie opłacone SettlementItem -> dla klienta powinien się pojawić przycisk
     settlementService.addUtilitySettlementItem(
-            settlementId,
-            unitId,
-            mapUtilityType(utilityType),
-            descriptionFor(utilityType),
-            consumptionDifference,
-            unitPrice);
+        settlementId,
+        unitId,
+        mapUtilityType(utilityType),
+        descriptionFor(utilityType),
+        consumptionDifference,
+        unitPrice);
   }
 
   private SettlementItemType mapUtilityType(UtilityType utilityType) {

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
@@ -48,9 +48,16 @@ public class MediaReadingService {
 
   @Transactional
   public void addFinalMediaReading(
-      UUID settlementId, UUID unitId, BigDecimal finalReading, BigDecimal finalConfidenceScore) {
+      UUID settlementId,
+      UUID unitId,
+      UtilityType utilityType,
+      BigDecimal finalReading,
+      BigDecimal finalConfidenceScore) {
 
-    MediaReading reading = mediaReadingRepository.findBySettlementId(settlementId).orElse(null);
+    MediaReading reading =
+        mediaReadingRepository
+            .findBySettlementIdAndUtilityType(settlementId, utilityType)
+            .orElse(null);
 
     if (reading == null) {
       throw new EntityNotFoundException(
@@ -77,8 +84,8 @@ public class MediaReadingService {
 
     mediaReadingRepository.save(reading);
 
-    UtilityType utilityType = reading.getUtilityType();
     BigDecimal unitPrice = reading.getUnitPrice();
+
     BigDecimal consumptionDifference = finalReading.subtract(reading.getInitialReading());
 
     // Tworzy się jeszcze nie opłacone SettlementItem -> dla klienta powinien się pojawić przycisk

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
@@ -1,0 +1,76 @@
+package io.github.kwatera_project.kwatera.billing_service.service;
+
+import io.github.kwatera_project.kwatera.billing_service.model.MediaReading;
+import io.github.kwatera_project.kwatera.billing_service.model.ReadingSource;
+import io.github.kwatera_project.kwatera.billing_service.model.ReadingStatus;
+import io.github.kwatera_project.kwatera.billing_service.model.SettlementItem;
+import io.github.kwatera_project.kwatera.billing_service.model.SettlementItemType;
+import io.github.kwatera_project.kwatera.billing_service.model.UtilityType;
+import io.github.kwatera_project.kwatera.billing_service.repository.MediaReadingRepository;
+import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MediaReadingService {
+
+  private final MediaReadingRepository mediaReadingRepository;
+  private final SettlementService settlementService;
+
+  @Transactional
+  public MediaReading createFinalizedMediaReadingCharge(
+      UUID settlementId,
+      UUID unitId,
+      UtilityType utilityType,
+      BigDecimal initialReading,
+      BigDecimal initialConfidenceScore,
+      BigDecimal finalReading,
+      BigDecimal finalConfidenceScore,
+      BigDecimal unitPrice,
+      ReadingSource readingSource,
+      ReadingStatus readingStatus) {
+    if (finalReading == null) {
+      throw new IllegalArgumentException("Final reading is required");
+    }
+
+    if (finalReading.compareTo(initialReading) < 0) {
+      throw new IllegalArgumentException("Final reading cannot be lower than initial reading");
+    }
+
+    BigDecimal consumption = finalReading.subtract(initialReading);
+    SettlementItemType itemType = mapUtilityType(utilityType);
+    SettlementItem item =
+        settlementService.addUtilityCharge(
+            settlementId, unitId, itemType, descriptionFor(utilityType), consumption, unitPrice);
+
+    MediaReading reading = new MediaReading();
+    reading.setSettlementItemId(item.getId());
+    reading.setUtilityType(utilityType);
+    reading.setInitialReading(initialReading);
+    reading.setInitialConfidenceScore(initialConfidenceScore);
+    reading.setFinalReading(finalReading);
+    reading.setFinalConfidenceScore(finalConfidenceScore);
+    reading.setUnitPrice(unitPrice);
+    reading.setReadingSource(readingSource);
+    reading.setReadingStatus(readingStatus);
+
+    return mediaReadingRepository.save(reading);
+  }
+
+  private SettlementItemType mapUtilityType(UtilityType utilityType) {
+    return switch (utilityType) {
+      case WATER -> SettlementItemType.WATER;
+      case ELECTRICITY -> SettlementItemType.ELECTRICITY;
+    };
+  }
+
+  private String descriptionFor(UtilityType utilityType) {
+    return switch (utilityType) {
+      case WATER -> "Water usage";
+      case ELECTRICITY -> "Electricity usage";
+    };
+  }
+}

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingService.java
@@ -1,12 +1,13 @@
 package io.github.kwatera_project.kwatera.billing_service.service;
 
+import static io.github.kwatera_project.kwatera.billing_service.model.ReadingStatus.PENDING;
+
 import io.github.kwatera_project.kwatera.billing_service.model.MediaReading;
 import io.github.kwatera_project.kwatera.billing_service.model.ReadingSource;
-import io.github.kwatera_project.kwatera.billing_service.model.ReadingStatus;
-import io.github.kwatera_project.kwatera.billing_service.model.SettlementItem;
 import io.github.kwatera_project.kwatera.billing_service.model.SettlementItemType;
 import io.github.kwatera_project.kwatera.billing_service.model.UtilityType;
 import io.github.kwatera_project.kwatera.billing_service.repository.MediaReadingRepository;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -21,43 +22,73 @@ public class MediaReadingService {
   private final SettlementService settlementService;
 
   @Transactional
-  public MediaReading createFinalizedMediaReadingCharge(
+  public void createMediaReadingWithInitialReading(
       UUID settlementId,
-      UUID unitId,
       UtilityType utilityType,
       BigDecimal initialReading,
       BigDecimal initialConfidenceScore,
-      BigDecimal finalReading,
-      BigDecimal finalConfidenceScore,
       BigDecimal unitPrice,
-      ReadingSource readingSource,
-      ReadingStatus readingStatus) {
+      ReadingSource readingSource) {
+
+    MediaReading reading = new MediaReading();
+    reading.setSettlementId(settlementId);
+    reading.setUtilityType(utilityType);
+    reading.setInitialReading(initialReading);
+    reading.setInitialConfidenceScore(initialConfidenceScore);
+    reading.setUnitPrice(unitPrice);
+    reading.setReadingSource(readingSource);
+
+    // Tu warto dodać sprawdzenie initialConfidenceScore i w zależności od tego ustawić
+    // setReadingStatus()
+
+    reading.setReadingStatus(PENDING);
+
+    mediaReadingRepository.save(reading);
+  }
+
+  @Transactional
+  public void addFinalMediaReading(
+      UUID settlementId, UUID unitId, BigDecimal finalReading, BigDecimal finalConfidenceScore) {
+
+    MediaReading reading = mediaReadingRepository.findBySettlementId(settlementId).orElse(null);
+
+    if (reading == null) {
+      throw new EntityNotFoundException(
+          "Media Reading not found for settlementId: " + settlementId);
+    }
+
     if (finalReading == null) {
       throw new IllegalArgumentException("Final reading is required");
     }
 
-    if (finalReading.compareTo(initialReading) < 0) {
+    if (finalReading.compareTo(reading.getInitialReading()) < 0) {
       throw new IllegalArgumentException("Final reading cannot be lower than initial reading");
     }
 
-    BigDecimal consumption = finalReading.subtract(initialReading);
-    SettlementItemType itemType = mapUtilityType(utilityType);
-    SettlementItem item =
-        settlementService.addUtilityCharge(
-            settlementId, unitId, itemType, descriptionFor(utilityType), consumption, unitPrice);
-
-    MediaReading reading = new MediaReading();
-    reading.setSettlementItemId(item.getId());
-    reading.setUtilityType(utilityType);
-    reading.setInitialReading(initialReading);
-    reading.setInitialConfidenceScore(initialConfidenceScore);
     reading.setFinalReading(finalReading);
     reading.setFinalConfidenceScore(finalConfidenceScore);
-    reading.setUnitPrice(unitPrice);
-    reading.setReadingSource(readingSource);
-    reading.setReadingStatus(readingStatus);
 
-    return mediaReadingRepository.save(reading);
+    // Wartości się przeliczają na poziomie bazy
+
+    // Tu warto dodać sprawdzenie finalConfidenceScore i w zależności od tego ustawić
+    // setReadingStatus()
+
+    reading.setReadingStatus(PENDING);
+
+    mediaReadingRepository.save(reading);
+
+    UtilityType utilityType = reading.getUtilityType();
+    BigDecimal unit_price = reading.getUnitPrice();
+    BigDecimal consumption_difference = reading.getConsumptionDifference();
+
+    // Tworzy się jeszcze nie opłacone SelletentItem -> dla klienta powinien się pojawić przycisk
+    settlementService.addUtilitySettlementItem(
+        settlementId,
+        unitId,
+        mapUtilityType(utilityType),
+        descriptionFor(utilityType),
+        consumption_difference,
+        unit_price);
   }
 
   private SettlementItemType mapUtilityType(UtilityType utilityType) {

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementService.java
@@ -67,6 +67,36 @@ public class SettlementService {
     settlementRepository.save(settlement);
   }
 
+  @Transactional
+  public SettlementItem addUtilityCharge(
+      UUID settlementId,
+      UUID unitId,
+      SettlementItemType type,
+      String description,
+      BigDecimal quantity,
+      BigDecimal unitPrice) {
+    if (type != WATER && type != ELECTRICITY) {
+      throw new IllegalArgumentException(
+          "Only water and electricity utility charges are supported");
+    }
+
+    Settlement settlement =
+        settlementRepository
+            .findById(settlementId)
+            .orElseThrow(() -> new RuntimeException(SETTLEMENT_NOT_FOUND));
+
+    SettlementItem item =
+        createSettlementItem(settlementId, type, description, quantity, unitPrice);
+
+    applyItemToSettlement(settlement, item);
+    recalculateTotals(settlement);
+    recalculateSettlementStatus(settlement, unitId);
+
+    settlementRepository.save(settlement);
+
+    return item;
+  }
+
   private void applyItemToSettlement(Settlement settlement, SettlementItem item) {
 
     BigDecimal amount = item.getAmount();

--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementService.java
@@ -68,13 +68,14 @@ public class SettlementService {
   }
 
   @Transactional
-  public SettlementItem addUtilityCharge(
+  public SettlementItem addUtilitySettlementItem(
       UUID settlementId,
       UUID unitId,
       SettlementItemType type,
       String description,
       BigDecimal quantity,
       BigDecimal unitPrice) {
+
     if (type != WATER && type != ELECTRICITY) {
       throw new IllegalArgumentException(
           "Only water and electricity utility charges are supported");

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepositoryTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepositoryTest.java
@@ -51,7 +51,7 @@ public class MediaReadingRepositoryTest {
   void shouldCalculateConsumptionDifferenceAndCost() {
     MediaReading reading = new MediaReading();
 
-    reading.setSettlementItemId(UUID.randomUUID());
+    reading.setSettlementId(UUID.randomUUID());
     reading.setUtilityType(UtilityType.WATER);
 
     reading.setInitialReading(new BigDecimal("100.000"));
@@ -78,7 +78,7 @@ public class MediaReadingRepositoryTest {
   void shouldReturnNullCalculatedFieldsWhenFinalReadingIsNull() {
     MediaReading reading = new MediaReading();
 
-    reading.setSettlementItemId(UUID.randomUUID());
+    reading.setSettlementId(UUID.randomUUID());
     reading.setUtilityType(UtilityType.WATER);
 
     reading.setInitialReading(new BigDecimal("200.000"));
@@ -101,7 +101,7 @@ public class MediaReadingRepositoryTest {
   void shouldFailWhenFinalReadingIsLowerThanInitial() {
     MediaReading reading = new MediaReading();
 
-    reading.setSettlementItemId(UUID.randomUUID());
+    reading.setSettlementId(UUID.randomUUID());
     reading.setUtilityType(UtilityType.ELECTRICITY);
 
     reading.setInitialReading(new BigDecimal("500"));

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepositoryTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/repository/MediaReadingRepositoryTest.java
@@ -1,0 +1,118 @@
+package io.github.kwatera_project.kwatera.billing_service.repository;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.github.kwatera_project.kwatera.billing_service.model.MediaReading;
+import io.github.kwatera_project.kwatera.billing_service.model.UtilityType;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@ActiveProfiles("integration-test")
+@Testcontainers
+@Transactional
+public class MediaReadingRepositoryTest {
+
+  @Autowired private MediaReadingRepository repository;
+
+  @Autowired private EntityManager entityManager;
+
+  @Container
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:16")
+          .withDatabaseName("test")
+          .withUsername("test")
+          .withPassword("test");
+
+  @DynamicPropertySource
+  static void configure(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.datasource.driver-class-name", postgres::getDriverClassName);
+
+    registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+  }
+
+  @Test
+  void shouldCalculateConsumptionDifferenceAndCost() {
+    MediaReading reading = new MediaReading();
+
+    reading.setSettlementItemId(UUID.randomUUID());
+    reading.setUtilityType(UtilityType.WATER);
+
+    reading.setInitialReading(new BigDecimal("100.000"));
+    reading.setInitialConfidenceScore(new BigDecimal("0.95"));
+
+    reading.setFinalReading(new BigDecimal("150.000"));
+    reading.setFinalConfidenceScore(new BigDecimal("0.98"));
+
+    reading.setUnitPrice(new BigDecimal("2.50"));
+
+    MediaReading saved = repository.save(reading);
+
+    entityManager.flush();
+
+    entityManager.clear();
+
+    MediaReading refreshed = repository.findById(saved.getId()).orElseThrow();
+
+    assertThat(refreshed.getConsumptionDifference()).isEqualByComparingTo("50.000000");
+    assertThat(refreshed.getCalculatedCost()).isEqualByComparingTo("125.00");
+  }
+
+  @Test
+  void shouldReturnNullCalculatedFieldsWhenFinalReadingIsNull() {
+    MediaReading reading = new MediaReading();
+
+    reading.setSettlementItemId(UUID.randomUUID());
+    reading.setUtilityType(UtilityType.WATER);
+
+    reading.setInitialReading(new BigDecimal("200.000"));
+    reading.setInitialConfidenceScore(new BigDecimal("0.90"));
+
+    reading.setUnitPrice(new BigDecimal("3.00"));
+
+    MediaReading saved = repository.save(reading);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    MediaReading refreshed = repository.findById(saved.getId()).orElseThrow();
+
+    assertThat(refreshed.getConsumptionDifference()).isNull();
+    assertThat(refreshed.getCalculatedCost()).isNull();
+  }
+
+  @Test
+  void shouldFailWhenFinalReadingIsLowerThanInitial() {
+    MediaReading reading = new MediaReading();
+
+    reading.setSettlementItemId(UUID.randomUUID());
+    reading.setUtilityType(UtilityType.ELECTRICITY);
+
+    reading.setInitialReading(new BigDecimal("500"));
+    reading.setInitialConfidenceScore(new BigDecimal("0.90"));
+
+    reading.setFinalReading(new BigDecimal("400"));
+    reading.setFinalConfidenceScore(new BigDecimal("0.90"));
+
+    reading.setUnitPrice(new BigDecimal("1.20"));
+
+    assertThatThrownBy(() -> repository.saveAndFlush(reading))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+}

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
@@ -192,21 +192,21 @@ class MediaReadingServiceTest {
     existingReading.setUnitPrice(unitPrice);
 
     when(mediaReadingRepository.findBySettlementId(settlementId))
-            .thenReturn(Optional.of(existingReading));
+        .thenReturn(Optional.of(existingReading));
 
     when(mediaReadingRepository.save(any(MediaReading.class)))
-            .thenAnswer(invocation -> invocation.getArgument(0));
+        .thenAnswer(invocation -> invocation.getArgument(0));
 
     mediaReadingService.addFinalMediaReading(
-            settlementId, unitId, finalReading, new BigDecimal("0.99"));
+        settlementId, unitId, finalReading, new BigDecimal("0.99"));
 
     verify(settlementService)
-            .addUtilitySettlementItem(
-                    eq(settlementId),
-                    eq(unitId),
-                    eq(SettlementItemType.WATER),
-                    eq("Water usage"),
-                    eq(expectedConsumptionDifference),
-                    eq(unitPrice));
+        .addUtilitySettlementItem(
+            eq(settlementId),
+            eq(unitId),
+            eq(SettlementItemType.WATER),
+            eq("Water usage"),
+            eq(expectedConsumptionDifference),
+            eq(unitPrice));
   }
 }

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
@@ -33,10 +33,11 @@ class MediaReadingServiceTest {
     BigDecimal finalValue = new BigDecimal("108.000000");
     BigDecimal diff = new BigDecimal("8.000000");
     BigDecimal unitPrice = new BigDecimal("5.00");
+    UtilityType type = UtilityType.WATER;
 
     MediaReading existingReading = new MediaReading();
     existingReading.setSettlementId(settlementId);
-    existingReading.setUtilityType(UtilityType.WATER);
+    existingReading.setUtilityType(type);
     existingReading.setInitialReading(initialValue);
     existingReading.setUnitPrice(unitPrice);
 
@@ -47,7 +48,7 @@ class MediaReadingServiceTest {
     SettlementItem mockItem = new SettlementItem();
     mockItem.setId(settlementItemId);
 
-    when(mediaReadingRepository.findBySettlementId(settlementId))
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, type))
         .thenReturn(Optional.of(existingReading));
 
     when(settlementService.addUtilitySettlementItem(
@@ -63,7 +64,7 @@ class MediaReadingServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     mediaReadingService.addFinalMediaReading(
-        settlementId, unitId, finalValue, new BigDecimal("0.99"));
+        settlementId, unitId, type, finalValue, new BigDecimal("0.99"));
 
     verify(settlementService)
         .addUtilitySettlementItem(
@@ -117,12 +118,14 @@ class MediaReadingServiceTest {
     UUID unitId = UUID.randomUUID();
     BigDecimal initialReading = new BigDecimal("100.00");
     BigDecimal invalidLowerFinalReading = new BigDecimal("90.00"); // Wartość mniejsza niż initial
+    UtilityType type = UtilityType.WATER;
 
     MediaReading existingReading = new MediaReading();
     existingReading.setSettlementId(settlementId);
     existingReading.setInitialReading(initialReading);
+    existingReading.setUtilityType(type);
 
-    when(mediaReadingRepository.findBySettlementId(settlementId))
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, type))
         .thenReturn(Optional.of(existingReading));
 
     IllegalArgumentException exception =
@@ -130,7 +133,7 @@ class MediaReadingServiceTest {
             IllegalArgumentException.class,
             () -> {
               mediaReadingService.addFinalMediaReading(
-                  settlementId, unitId, invalidLowerFinalReading, new BigDecimal("0.99"));
+                  settlementId, unitId, type, invalidLowerFinalReading, new BigDecimal("0.99"));
             });
 
     assertEquals("Final reading cannot be lower than initial reading", exception.getMessage());
@@ -149,19 +152,20 @@ class MediaReadingServiceTest {
     BigDecimal finalReading = new BigDecimal("1250.00");
     BigDecimal consumptionDiff = new BigDecimal("250.00");
     BigDecimal unitPrice = new BigDecimal("0.90");
+    UtilityType type = UtilityType.ELECTRICITY;
 
     MediaReading electricityReading = new MediaReading();
     electricityReading.setSettlementId(settlementId);
-    electricityReading.setUtilityType(UtilityType.ELECTRICITY);
+    electricityReading.setUtilityType(type);
     electricityReading.setInitialReading(initialReading);
     electricityReading.setUnitPrice(unitPrice);
     electricityReading.setConsumptionDifference(consumptionDiff);
 
-    when(mediaReadingRepository.findBySettlementId(settlementId))
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, type))
         .thenReturn(Optional.of(electricityReading));
 
     mediaReadingService.addFinalMediaReading(
-        settlementId, unitId, finalReading, new BigDecimal("0.95"));
+        settlementId, unitId, type, finalReading, new BigDecimal("0.95"));
 
     verify(settlementService)
         .addUtilitySettlementItem(
@@ -184,21 +188,22 @@ class MediaReadingServiceTest {
     BigDecimal finalReading = new BigDecimal("108.000000");
     BigDecimal expectedConsumptionDifference = new BigDecimal("8.000000");
     BigDecimal unitPrice = new BigDecimal("5.00");
+    UtilityType type = UtilityType.WATER;
 
     MediaReading existingReading = new MediaReading();
     existingReading.setSettlementId(settlementId);
-    existingReading.setUtilityType(UtilityType.WATER);
+    existingReading.setUtilityType(type);
     existingReading.setInitialReading(initialReading);
     existingReading.setUnitPrice(unitPrice);
 
-    when(mediaReadingRepository.findBySettlementId(settlementId))
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, type))
         .thenReturn(Optional.of(existingReading));
 
     when(mediaReadingRepository.save(any(MediaReading.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
     mediaReadingService.addFinalMediaReading(
-        settlementId, unitId, finalReading, new BigDecimal("0.99"));
+        settlementId, unitId, type, finalReading, new BigDecimal("0.99"));
 
     verify(settlementService)
         .addUtilitySettlementItem(
@@ -208,5 +213,63 @@ class MediaReadingServiceTest {
             eq("Water usage"),
             eq(expectedConsumptionDifference),
             eq(unitPrice));
+  }
+
+  @Test
+  void shouldFinalizeOnlyWaterReadingWithoutTouchingElectricityReading() {
+
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+
+    BigDecimal waterInitial = new BigDecimal("100.00");
+    BigDecimal waterFinal = new BigDecimal("120.00");
+    BigDecimal waterUnitPrice = new BigDecimal("5.00");
+
+    BigDecimal electricityInitial = new BigDecimal("1000.00");
+
+    MediaReading waterReading = new MediaReading();
+    waterReading.setSettlementId(settlementId);
+    waterReading.setUtilityType(UtilityType.WATER);
+    waterReading.setInitialReading(waterInitial);
+    waterReading.setUnitPrice(waterUnitPrice);
+
+    MediaReading electricityReading = new MediaReading();
+    electricityReading.setSettlementId(settlementId);
+    electricityReading.setUtilityType(UtilityType.ELECTRICITY);
+    electricityReading.setInitialReading(electricityInitial);
+
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
+        .thenReturn(Optional.of(waterReading));
+
+    when(mediaReadingRepository.save(any(MediaReading.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    mediaReadingService.addFinalMediaReading(
+        settlementId, unitId, UtilityType.WATER, waterFinal, new BigDecimal("0.99"));
+
+    // WATER został zakończony
+    assertEquals(waterFinal, waterReading.getFinalReading());
+
+    // ELECTRICITY pozostał nietknięty
+    assertNull(electricityReading.getFinalReading());
+
+    verify(settlementService)
+        .addUtilitySettlementItem(
+            eq(settlementId),
+            eq(unitId),
+            eq(SettlementItemType.WATER),
+            eq("Water usage"),
+            eq(new BigDecimal("20.00")),
+            eq(waterUnitPrice));
+
+    // Brak settlement item dla ELECTRICITY
+    verify(settlementService, never())
+        .addUtilitySettlementItem(
+            eq(settlementId),
+            eq(unitId),
+            eq(SettlementItemType.ELECTRICITY),
+            anyString(),
+            any(),
+            any());
   }
 }

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
@@ -174,4 +174,39 @@ class MediaReadingServiceTest {
 
     assertEquals(finalReading, electricityReading.getFinalReading());
   }
+
+  @Test
+  void shouldCalculateConsumptionDifferenceFromInitialAndFinalReadingWhenFinalReadingIsAdded() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+
+    BigDecimal initialReading = new BigDecimal("100.000000");
+    BigDecimal finalReading = new BigDecimal("108.000000");
+    BigDecimal expectedConsumptionDifference = new BigDecimal("8.000000");
+    BigDecimal unitPrice = new BigDecimal("5.00");
+
+    MediaReading existingReading = new MediaReading();
+    existingReading.setSettlementId(settlementId);
+    existingReading.setUtilityType(UtilityType.WATER);
+    existingReading.setInitialReading(initialReading);
+    existingReading.setUnitPrice(unitPrice);
+
+    when(mediaReadingRepository.findBySettlementId(settlementId))
+            .thenReturn(Optional.of(existingReading));
+
+    when(mediaReadingRepository.save(any(MediaReading.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+    mediaReadingService.addFinalMediaReading(
+            settlementId, unitId, finalReading, new BigDecimal("0.99"));
+
+    verify(settlementService)
+            .addUtilitySettlementItem(
+                    eq(settlementId),
+                    eq(unitId),
+                    eq(SettlementItemType.WATER),
+                    eq("Water usage"),
+                    eq(expectedConsumptionDifference),
+                    eq(unitPrice));
+  }
 }

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
@@ -1,0 +1,179 @@
+package io.github.kwatera_project.kwatera.billing_service.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.kwatera_project.kwatera.billing_service.model.MediaReading;
+import io.github.kwatera_project.kwatera.billing_service.model.ReadingSource;
+import io.github.kwatera_project.kwatera.billing_service.model.ReadingStatus;
+import io.github.kwatera_project.kwatera.billing_service.model.SettlementItem;
+import io.github.kwatera_project.kwatera.billing_service.model.SettlementItemType;
+import io.github.kwatera_project.kwatera.billing_service.model.UtilityType;
+import io.github.kwatera_project.kwatera.billing_service.repository.MediaReadingRepository;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MediaReadingServiceTest {
+
+  @Mock private MediaReadingRepository mediaReadingRepository;
+
+  @Mock private SettlementService settlementService;
+
+  @InjectMocks private MediaReadingService mediaReadingService;
+
+  @Test
+  void shouldCreateSettlementItemFromFinalizedWaterReading() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID settlementItemId = UUID.randomUUID();
+    SettlementItem item = new SettlementItem();
+    item.setId(settlementItemId);
+
+    when(settlementService.addUtilityCharge(
+            eq(settlementId),
+            eq(unitId),
+            eq(SettlementItemType.WATER),
+            eq("Water usage"),
+            eq(new BigDecimal("8.000000")),
+            eq(new BigDecimal("5.00"))))
+        .thenReturn(item);
+    when(mediaReadingRepository.save(any(MediaReading.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    MediaReading reading =
+        mediaReadingService.createFinalizedMediaReadingCharge(
+            settlementId,
+            unitId,
+            UtilityType.WATER,
+            new BigDecimal("100.000000"),
+            new BigDecimal("0.982145"),
+            new BigDecimal("108.000000"),
+            new BigDecimal("0.997531"),
+            new BigDecimal("5.00"),
+            ReadingSource.OCR,
+            ReadingStatus.AUTO_APPROVED);
+
+    assertEquals(settlementItemId, reading.getSettlementItemId());
+    assertEquals(UtilityType.WATER, reading.getUtilityType());
+    verify(settlementService)
+        .addUtilityCharge(
+            settlementId,
+            unitId,
+            SettlementItemType.WATER,
+            "Water usage",
+            new BigDecimal("8.000000"),
+            new BigDecimal("5.00"));
+  }
+
+  @Test
+  void shouldSaveMediaReadingLinkedToCreatedSettlementItem() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID settlementItemId = UUID.randomUUID();
+    SettlementItem item = new SettlementItem();
+    item.setId(settlementItemId);
+    ArgumentCaptor<MediaReading> readingCaptor = ArgumentCaptor.forClass(MediaReading.class);
+
+    when(settlementService.addUtilityCharge(any(), any(), any(), any(), any(), any()))
+        .thenReturn(item);
+    when(mediaReadingRepository.save(any(MediaReading.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    mediaReadingService.createFinalizedMediaReadingCharge(
+        settlementId,
+        unitId,
+        UtilityType.WATER,
+        new BigDecimal("100.000000"),
+        new BigDecimal("0.982145"),
+        new BigDecimal("108.000000"),
+        new BigDecimal("0.997531"),
+        new BigDecimal("5.00"),
+        ReadingSource.OCR,
+        ReadingStatus.AUTO_APPROVED);
+
+    verify(mediaReadingRepository).save(readingCaptor.capture());
+    MediaReading savedReading = readingCaptor.getValue();
+
+    assertEquals(settlementItemId, savedReading.getSettlementItemId());
+    assertEquals(new BigDecimal("100.000000"), savedReading.getInitialReading());
+    assertEquals(new BigDecimal("108.000000"), savedReading.getFinalReading());
+    assertEquals(new BigDecimal("5.00"), savedReading.getUnitPrice());
+    assertEquals(ReadingStatus.AUTO_APPROVED, savedReading.getReadingStatus());
+  }
+
+  @Test
+  void shouldRejectFinalReadingLowerThanInitial() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            mediaReadingService.createFinalizedMediaReadingCharge(
+                settlementId,
+                unitId,
+                UtilityType.WATER,
+                new BigDecimal("108.000000"),
+                new BigDecimal("0.982145"),
+                new BigDecimal("100.000000"),
+                new BigDecimal("0.997531"),
+                new BigDecimal("5.00"),
+                ReadingSource.OCR,
+                ReadingStatus.AUTO_APPROVED));
+
+    verify(settlementService, never()).addUtilityCharge(any(), any(), any(), any(), any(), any());
+    verify(mediaReadingRepository, never()).save(any());
+  }
+
+  @Test
+  void shouldMapElectricityReadingToElectricitySettlementItem() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    SettlementItem item = new SettlementItem();
+    item.setId(UUID.randomUUID());
+
+    when(settlementService.addUtilityCharge(
+            eq(settlementId),
+            eq(unitId),
+            eq(SettlementItemType.ELECTRICITY),
+            eq("Electricity usage"),
+            eq(new BigDecimal("40.000000")),
+            eq(new BigDecimal("1.20"))))
+        .thenReturn(item);
+    when(mediaReadingRepository.save(any(MediaReading.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    mediaReadingService.createFinalizedMediaReadingCharge(
+        settlementId,
+        unitId,
+        UtilityType.ELECTRICITY,
+        new BigDecimal("500.000000"),
+        new BigDecimal("0.982145"),
+        new BigDecimal("540.000000"),
+        new BigDecimal("0.997531"),
+        new BigDecimal("1.20"),
+        ReadingSource.OCR,
+        ReadingStatus.AUTO_APPROVED);
+
+    verify(settlementService)
+        .addUtilityCharge(
+            settlementId,
+            unitId,
+            SettlementItemType.ELECTRICITY,
+            "Electricity usage",
+            new BigDecimal("40.000000"),
+            new BigDecimal("1.20"));
+  }
+}

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
@@ -1,21 +1,13 @@
 package io.github.kwatera_project.kwatera.billing_service.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
-import io.github.kwatera_project.kwatera.billing_service.model.MediaReading;
-import io.github.kwatera_project.kwatera.billing_service.model.ReadingSource;
-import io.github.kwatera_project.kwatera.billing_service.model.ReadingStatus;
-import io.github.kwatera_project.kwatera.billing_service.model.SettlementItem;
-import io.github.kwatera_project.kwatera.billing_service.model.SettlementItemType;
-import io.github.kwatera_project.kwatera.billing_service.model.UtilityType;
+import io.github.kwatera_project.kwatera.billing_service.model.*;
 import io.github.kwatera_project.kwatera.billing_service.repository.MediaReadingRepository;
 import java.math.BigDecimal;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,143 +29,149 @@ class MediaReadingServiceTest {
   void shouldCreateSettlementItemFromFinalizedWaterReading() {
     UUID settlementId = UUID.randomUUID();
     UUID unitId = UUID.randomUUID();
-    UUID settlementItemId = UUID.randomUUID();
-    SettlementItem item = new SettlementItem();
-    item.setId(settlementItemId);
+    BigDecimal initialValue = new BigDecimal("100.000000");
+    BigDecimal finalValue = new BigDecimal("108.000000");
+    BigDecimal diff = new BigDecimal("8.000000");
+    BigDecimal unitPrice = new BigDecimal("5.00");
 
-    when(settlementService.addUtilityCharge(
+    MediaReading existingReading = new MediaReading();
+    existingReading.setSettlementId(settlementId);
+    existingReading.setUtilityType(UtilityType.WATER);
+    existingReading.setInitialReading(initialValue);
+    existingReading.setUnitPrice(unitPrice);
+
+    // Ustawiamy ręcznie wynik różnicy, ponieważ Mockito nie uruchomi logiki DB/Entity
+    existingReading.setConsumptionDifference(diff);
+
+    UUID settlementItemId = UUID.randomUUID();
+    SettlementItem mockItem = new SettlementItem();
+    mockItem.setId(settlementItemId);
+
+    when(mediaReadingRepository.findBySettlementId(settlementId))
+        .thenReturn(Optional.of(existingReading));
+
+    when(settlementService.addUtilitySettlementItem(
             eq(settlementId),
             eq(unitId),
             eq(SettlementItemType.WATER),
             eq("Water usage"),
-            eq(new BigDecimal("8.000000")),
-            eq(new BigDecimal("5.00"))))
-        .thenReturn(item);
+            eq(diff),
+            eq(unitPrice)))
+        .thenReturn(mockItem);
+
     when(mediaReadingRepository.save(any(MediaReading.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
-    MediaReading reading =
-        mediaReadingService.createFinalizedMediaReadingCharge(
-            settlementId,
-            unitId,
-            UtilityType.WATER,
-            new BigDecimal("100.000000"),
-            new BigDecimal("0.982145"),
-            new BigDecimal("108.000000"),
-            new BigDecimal("0.997531"),
-            new BigDecimal("5.00"),
-            ReadingSource.OCR,
-            ReadingStatus.AUTO_APPROVED);
+    mediaReadingService.addFinalMediaReading(
+        settlementId, unitId, finalValue, new BigDecimal("0.99"));
 
-    assertEquals(settlementItemId, reading.getSettlementItemId());
-    assertEquals(UtilityType.WATER, reading.getUtilityType());
     verify(settlementService)
-        .addUtilityCharge(
-            settlementId,
-            unitId,
-            SettlementItemType.WATER,
-            "Water usage",
-            new BigDecimal("8.000000"),
-            new BigDecimal("5.00"));
+        .addUtilitySettlementItem(
+            eq(settlementId),
+            eq(unitId),
+            eq(SettlementItemType.WATER),
+            anyString(),
+            eq(diff),
+            eq(unitPrice));
+
+    assertEquals(finalValue, existingReading.getFinalReading());
+    assertEquals(settlementId, existingReading.getSettlementId());
   }
 
   @Test
-  void shouldSaveMediaReadingLinkedToCreatedSettlementItem() {
+  void shouldCreateAndSaveInitialMediaReading() {
+
     UUID settlementId = UUID.randomUUID();
-    UUID unitId = UUID.randomUUID();
-    UUID settlementItemId = UUID.randomUUID();
-    SettlementItem item = new SettlementItem();
-    item.setId(settlementItemId);
+    UtilityType utilityType = UtilityType.WATER;
+    BigDecimal initialReading = new BigDecimal("100.00");
+    BigDecimal confidenceScore = new BigDecimal("0.98");
+    BigDecimal unitPrice = new BigDecimal("5.50");
+    ReadingSource source = ReadingSource.OCR;
+
     ArgumentCaptor<MediaReading> readingCaptor = ArgumentCaptor.forClass(MediaReading.class);
 
-    when(settlementService.addUtilityCharge(any(), any(), any(), any(), any(), any()))
-        .thenReturn(item);
     when(mediaReadingRepository.save(any(MediaReading.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
 
-    mediaReadingService.createFinalizedMediaReadingCharge(
-        settlementId,
-        unitId,
-        UtilityType.WATER,
-        new BigDecimal("100.000000"),
-        new BigDecimal("0.982145"),
-        new BigDecimal("108.000000"),
-        new BigDecimal("0.997531"),
-        new BigDecimal("5.00"),
-        ReadingSource.OCR,
-        ReadingStatus.AUTO_APPROVED);
+    mediaReadingService.createMediaReadingWithInitialReading(
+        settlementId, utilityType, initialReading, confidenceScore, unitPrice, source);
 
-    verify(mediaReadingRepository).save(readingCaptor.capture());
+    verify(mediaReadingRepository, times(1)).save(readingCaptor.capture());
+
     MediaReading savedReading = readingCaptor.getValue();
 
-    assertEquals(settlementItemId, savedReading.getSettlementItemId());
-    assertEquals(new BigDecimal("100.000000"), savedReading.getInitialReading());
-    assertEquals(new BigDecimal("108.000000"), savedReading.getFinalReading());
-    assertEquals(new BigDecimal("5.00"), savedReading.getUnitPrice());
-    assertEquals(ReadingStatus.AUTO_APPROVED, savedReading.getReadingStatus());
+    assertEquals(settlementId, savedReading.getSettlementId());
+    assertEquals(utilityType, savedReading.getUtilityType());
+    assertEquals(initialReading, savedReading.getInitialReading());
+    assertEquals(confidenceScore, savedReading.getInitialConfidenceScore());
+    assertEquals(unitPrice, savedReading.getUnitPrice());
+    assertEquals(source, savedReading.getReadingSource());
+
+    assertEquals(ReadingStatus.PENDING, savedReading.getReadingStatus());
   }
 
   @Test
   void shouldRejectFinalReadingLowerThanInitial() {
+
     UUID settlementId = UUID.randomUUID();
     UUID unitId = UUID.randomUUID();
+    BigDecimal initialReading = new BigDecimal("100.00");
+    BigDecimal invalidLowerFinalReading = new BigDecimal("90.00"); // Wartość mniejsza niż initial
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            mediaReadingService.createFinalizedMediaReadingCharge(
-                settlementId,
-                unitId,
-                UtilityType.WATER,
-                new BigDecimal("108.000000"),
-                new BigDecimal("0.982145"),
-                new BigDecimal("100.000000"),
-                new BigDecimal("0.997531"),
-                new BigDecimal("5.00"),
-                ReadingSource.OCR,
-                ReadingStatus.AUTO_APPROVED));
+    MediaReading existingReading = new MediaReading();
+    existingReading.setSettlementId(settlementId);
+    existingReading.setInitialReading(initialReading);
 
-    verify(settlementService, never()).addUtilityCharge(any(), any(), any(), any(), any(), any());
+    when(mediaReadingRepository.findBySettlementId(settlementId))
+        .thenReturn(Optional.of(existingReading));
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              mediaReadingService.addFinalMediaReading(
+                  settlementId, unitId, invalidLowerFinalReading, new BigDecimal("0.99"));
+            });
+
+    assertEquals("Final reading cannot be lower than initial reading", exception.getMessage());
+
     verify(mediaReadingRepository, never()).save(any());
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
   }
 
   @Test
   void shouldMapElectricityReadingToElectricitySettlementItem() {
+
     UUID settlementId = UUID.randomUUID();
     UUID unitId = UUID.randomUUID();
-    SettlementItem item = new SettlementItem();
-    item.setId(UUID.randomUUID());
+    BigDecimal initialReading = new BigDecimal("1000.00");
+    BigDecimal finalReading = new BigDecimal("1250.00");
+    BigDecimal consumptionDiff = new BigDecimal("250.00");
+    BigDecimal unitPrice = new BigDecimal("0.90");
 
-    when(settlementService.addUtilityCharge(
+    MediaReading electricityReading = new MediaReading();
+    electricityReading.setSettlementId(settlementId);
+    electricityReading.setUtilityType(UtilityType.ELECTRICITY);
+    electricityReading.setInitialReading(initialReading);
+    electricityReading.setUnitPrice(unitPrice);
+    electricityReading.setConsumptionDifference(consumptionDiff);
+
+    when(mediaReadingRepository.findBySettlementId(settlementId))
+        .thenReturn(Optional.of(electricityReading));
+
+    mediaReadingService.addFinalMediaReading(
+        settlementId, unitId, finalReading, new BigDecimal("0.95"));
+
+    verify(settlementService)
+        .addUtilitySettlementItem(
             eq(settlementId),
             eq(unitId),
             eq(SettlementItemType.ELECTRICITY),
             eq("Electricity usage"),
-            eq(new BigDecimal("40.000000")),
-            eq(new BigDecimal("1.20"))))
-        .thenReturn(item);
-    when(mediaReadingRepository.save(any(MediaReading.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+            eq(consumptionDiff),
+            eq(unitPrice));
 
-    mediaReadingService.createFinalizedMediaReadingCharge(
-        settlementId,
-        unitId,
-        UtilityType.ELECTRICITY,
-        new BigDecimal("500.000000"),
-        new BigDecimal("0.982145"),
-        new BigDecimal("540.000000"),
-        new BigDecimal("0.997531"),
-        new BigDecimal("1.20"),
-        ReadingSource.OCR,
-        ReadingStatus.AUTO_APPROVED);
-
-    verify(settlementService)
-        .addUtilityCharge(
-            settlementId,
-            unitId,
-            SettlementItemType.ELECTRICITY,
-            "Electricity usage",
-            new BigDecimal("40.000000"),
-            new BigDecimal("1.20"));
+    assertEquals(finalReading, electricityReading.getFinalReading());
   }
 }

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementServiceTest.java
@@ -229,6 +229,66 @@ class SettlementServiceTest {
   }
 
   @Test
+  void shouldAddUtilityChargeWithoutIncreasingAmountPaid() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+
+    Settlement settlement = baseSettlement(settlementId);
+    settlement.setReservationId(UUID.randomUUID());
+    settlement.setAmountPaid(BigDecimal.valueOf(500));
+    settlement.setBalanceDue(BigDecimal.ZERO);
+
+    when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
+    when(settlementItemRepository.save(any(SettlementItem.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(settlementItemRepository.existsBySettlementIdAndTypeIn(any(), any())).thenReturn(true);
+
+    settlementService.addUtilityCharge(
+        settlementId,
+        unitId,
+        SettlementItemType.WATER,
+        "Water usage",
+        BigDecimal.valueOf(5),
+        BigDecimal.valueOf(20));
+
+    assertEquals(BigDecimal.valueOf(100), settlement.getUtilitiesAmount());
+    assertEquals(BigDecimal.valueOf(600), settlement.getTotalAmount());
+    assertEquals(BigDecimal.valueOf(500), settlement.getAmountPaid());
+    assertEquals(BigDecimal.valueOf(100), settlement.getBalanceDue());
+    verify(settlementRepository).save(settlement);
+  }
+
+  @Test
+  void shouldRecalculateBalanceDueWhenUtilityChargeAdded() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+
+    Settlement settlement = baseSettlement(settlementId);
+    settlement.setReservationId(UUID.randomUUID());
+    settlement.setAmountPaid(BigDecimal.valueOf(200));
+    settlement.setBalanceDue(BigDecimal.valueOf(300));
+
+    when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
+    when(settlementItemRepository.save(any(SettlementItem.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(settlementItemRepository.existsBySettlementIdAndTypeIn(any(), any())).thenReturn(true);
+
+    settlementService.addUtilityCharge(
+        settlementId,
+        unitId,
+        SettlementItemType.ELECTRICITY,
+        "Electricity usage",
+        BigDecimal.valueOf(10),
+        BigDecimal.valueOf(10));
+
+    assertEquals(BigDecimal.valueOf(100), settlement.getUtilitiesAmount());
+    assertEquals(BigDecimal.valueOf(600), settlement.getTotalAmount());
+    assertEquals(BigDecimal.valueOf(200), settlement.getAmountPaid());
+    assertEquals(BigDecimal.valueOf(400), settlement.getBalanceDue());
+    verify(settlementRepository).save(settlement);
+  }
+
+  @Test
   void shouldNotModifyAmountsForAccommodationPayment() {
     UUID settlementId = UUID.randomUUID();
     UUID unitId = UUID.randomUUID();

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementServiceTest.java
@@ -243,7 +243,7 @@ class SettlementServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
     when(settlementItemRepository.existsBySettlementIdAndTypeIn(any(), any())).thenReturn(true);
 
-    settlementService.addUtilityCharge(
+    settlementService.addUtilitySettlementItem(
         settlementId,
         unitId,
         SettlementItemType.WATER,
@@ -273,7 +273,7 @@ class SettlementServiceTest {
         .thenAnswer(invocation -> invocation.getArgument(0));
     when(settlementItemRepository.existsBySettlementIdAndTypeIn(any(), any())).thenReturn(true);
 
-    settlementService.addUtilityCharge(
+    settlementService.addUtilitySettlementItem(
         settlementId,
         unitId,
         SettlementItemType.ELECTRICITY,

--- a/services/billing-service/src/test/resources/application-integration-test.yml
+++ b/services/billing-service/src/test/resources/application-integration-test.yml
@@ -1,0 +1,9 @@
+spring:
+  jpa:
+    defer-datasource-initialization: false
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+  flyway:
+    enabled: true

--- a/services/db-migrations/src/main/resources/db/migration/V15__create_media_readings.sql
+++ b/services/db-migrations/src/main/resources/db/migration/V15__create_media_readings.sql
@@ -2,7 +2,7 @@ CREATE TABLE media_readings
 (
     id                       UUID PRIMARY KEY,
 
-    settlement_item_id       UUID           NOT NULL,
+    settlement_id       UUID           NOT NULL,
 
     utility_type             VARCHAR(50)    NOT NULL,
 
@@ -46,16 +46,16 @@ CREATE TABLE media_readings
         ),
 
     CONSTRAINT fk_media_readings_settlement_item
-        FOREIGN KEY (settlement_item_id)
-            REFERENCES settlement_items (id)
+        FOREIGN KEY (settlement_id)
+            REFERENCES settlements (id)
             ON DELETE CASCADE
 );
 
-CREATE INDEX idx_media_readings_settlement_item_id ON media_readings (settlement_item_id);
+CREATE INDEX idx_media_readings_settlement_id ON media_readings (settlement_id);
 CREATE INDEX idx_media_readings_reading_status ON media_readings (reading_status);
 
 INSERT INTO media_readings (id,
-                            settlement_item_id,
+                            settlement_id,
                             utility_type,
                             initial_reading,
                             initial_confidence_score,
@@ -65,12 +65,12 @@ INSERT INTO media_readings (id,
                             reading_source,
                             reading_status)
 VALUES (gen_random_uuid(),
-        'bbbbbbbb-bbbb-bbbb-bbbb-111111111112',
+        'aaaaaaaa-aaaa-aaaa-aaaa-111111111111',
         'WATER',
         100.000000,
         0.982145,
         108.000000,
         0.997531,
-        5.00,
+        18.50,
         'OCR',
         'AUTO_APPROVED');

--- a/services/db-migrations/src/main/resources/db/migration/V15__create_media_readings.sql
+++ b/services/db-migrations/src/main/resources/db/migration/V15__create_media_readings.sql
@@ -1,0 +1,76 @@
+CREATE TABLE media_readings
+(
+    id                       UUID PRIMARY KEY,
+
+    settlement_item_id       UUID           NOT NULL,
+
+    utility_type             VARCHAR(50)    NOT NULL,
+
+    initial_reading          NUMERIC(12, 6) NOT NULL,
+
+    initial_confidence_score NUMERIC(12, 6) NOT NULL,
+
+    final_reading            NUMERIC(12, 6),
+
+    final_confidence_score   NUMERIC(12, 6),
+
+    consumption_difference   NUMERIC(12, 6)
+        GENERATED ALWAYS AS (
+            CASE
+                WHEN final_reading IS NOT NULL
+                    THEN final_reading - initial_reading
+                ELSE NULL
+                END
+            ) STORED,
+
+    unit_price               NUMERIC(12, 2) NOT NULL,
+
+    calculated_cost          NUMERIC(12, 2)
+        GENERATED ALWAYS AS (
+            CASE
+                WHEN final_reading IS NOT NULL
+                    THEN (final_reading - initial_reading) * unit_price
+                ELSE NULL
+                END
+            ) STORED,
+
+    reading_source           VARCHAR(50)    NOT NULL DEFAULT 'OCR',
+    reading_status           VARCHAR(50)    NOT NULL DEFAULT 'PENDING',
+
+    created_at               TIMESTAMP               DEFAULT CURRENT_TIMESTAMP,
+    updated_at               TIMESTAMP               DEFAULT CURRENT_TIMESTAMP,
+
+    CHECK (
+        final_reading IS NULL
+            OR final_reading >= initial_reading
+        ),
+
+    CONSTRAINT fk_media_readings_settlement_item
+        FOREIGN KEY (settlement_item_id)
+            REFERENCES settlement_items (id)
+            ON DELETE CASCADE
+);
+
+CREATE INDEX idx_media_readings_settlement_item_id ON media_readings (settlement_item_id);
+CREATE INDEX idx_media_readings_reading_status ON media_readings (reading_status);
+
+INSERT INTO media_readings (id,
+                            settlement_item_id,
+                            utility_type,
+                            initial_reading,
+                            initial_confidence_score,
+                            final_reading,
+                            final_confidence_score,
+                            unit_price,
+                            reading_source,
+                            reading_status)
+VALUES (gen_random_uuid(),
+        'bbbbbbbb-bbbb-bbbb-bbbb-111111111112',
+        'WATER',
+        100.000000,
+        0.982145,
+        108.000000,
+        0.997531,
+        5.00,
+        'OCR',
+        'AUTO_APPROVED');


### PR DESCRIPTION
## Summary
Add media reading data model and utility cost calculation to the billing domain.

## Linked issue
Closes #60 

## Scope of changes

- Created new table `media_readings` with computed consumption and cost fields:

```
media_readings:

id                     
settlement_item_id      
utility_type          
initial_reading         
initial_confidence_score 
final_reading         
final_confidence_score  
consumption_difference   
unit_price              
calculated_cost          
reading_source          
reading_status           
created_at            
updated_at
```

- Created tests for media reading validation and utility cost calculation.


## Testing status
Describe how this was verified.

- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
- [x] Ready for review