### PR TITLE
Prevent duplicate utility charges for OCR media readings

### DIFF
--- a/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementService.java
+++ b/services/billing-service/src/main/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementService.java
@@ -85,6 +85,10 @@ public class SettlementService {
       throw new IllegalArgumentException(
           "Only water and electricity utility charges are supported");
     }
+    if (settlementItemRepository.findBySettlementIdAndType(settlementId, type).isPresent()) {
+      throw new IllegalStateException(
+          "Utility charge already exists for settlementId: " + settlementId + " and type: " + type);
+    }
 
     Settlement settlement =
         settlementRepository

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/MediaReadingServiceTest.java
@@ -127,6 +127,7 @@ class MediaReadingServiceTest {
                 settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile));
 
     verifyNoInteractions(ocrClient);
+    verifyNoInteractions(settlementService);
   }
 
   @Test
@@ -305,6 +306,8 @@ class MediaReadingServiceTest {
 
     assertEquals(ReadingStatus.REQUEST_MANUAL_REVIEW, status);
     assertNull(reading.getFinalReading());
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -348,6 +351,7 @@ class MediaReadingServiceTest {
                 settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile));
 
     verifyNoInteractions(ocrClient);
+    verifyNoInteractions(settlementService);
   }
 
   @Test
@@ -362,22 +366,9 @@ class MediaReadingServiceTest {
         () ->
             mediaReadingService.processFinalReadingUpload(
                 settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile));
-  }
 
-  @Test
-  void shouldRejectFinalUploadWhenStatusIsAlreadyApproved() throws Exception {
-    UUID settlementId = UUID.randomUUID();
-    MediaReading reading = new MediaReading();
-    reading.setFinalReadingStatus(ReadingStatus.AUTO_APPROVED);
-
-    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
-        .thenReturn(Optional.of(reading));
-
-    assertThrows(
-        IllegalStateException.class,
-        () ->
-            mediaReadingService.processFinalReadingUpload(
-                settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile));
+    verifyNoInteractions(ocrClient);
+    verifyNoInteractions(settlementService);
   }
 
   @Test
@@ -446,6 +437,8 @@ class MediaReadingServiceTest {
                 UtilityType.WATER,
                 new BigDecimal("140"),
                 ReadingType.FINAL));
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -487,6 +480,8 @@ class MediaReadingServiceTest {
                 UtilityType.WATER,
                 new BigDecimal("100"),
                 ReadingType.FINAL));
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -505,6 +500,7 @@ class MediaReadingServiceTest {
                 UtilityType.WATER,
                 new BigDecimal("140"),
                 ReadingType.FINAL));
+    verifyNoInteractions(settlementService);
   }
 
   @Test
@@ -592,6 +588,7 @@ class MediaReadingServiceTest {
 
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getInitialReadingStatus());
+    assertNull(reading.getInitialReading());
   }
 
   @Test
@@ -613,6 +610,7 @@ class MediaReadingServiceTest {
 
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getInitialReadingStatus());
+    assertNull(reading.getInitialReading());
   }
 
   @Test
@@ -635,28 +633,7 @@ class MediaReadingServiceTest {
 
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getInitialReadingStatus());
-  }
-
-  @Test
-  void shouldRequestReuploadWhenFinalOcrClientFails() throws Exception {
-    UUID settlementId = UUID.randomUUID();
-    MediaReading reading = new MediaReading();
-    reading.setInitialReading(new BigDecimal("100"));
-    reading.setInitialReadingStatus(ReadingStatus.AUTO_APPROVED);
-    reading.setFinalReadingStatus(ReadingStatus.PENDING);
-
-    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
-        .thenReturn(Optional.of(reading));
-    when(ocrClient.readMeter(multipartFile)).thenThrow(new RuntimeException("OCR failed"));
-    when(multipartFile.getBytes()).thenReturn(new byte[0]);
-
-    ReadingStatus status =
-        mediaReadingService.processFinalReadingUpload(
-            settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile);
-
-    assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
-    assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getFinalReadingStatus());
-    assertNull(reading.getFinalReading());
+    assertNull(reading.getInitialReading());
   }
 
   @Test
@@ -679,6 +656,8 @@ class MediaReadingServiceTest {
     assertEquals(ReadingStatus.REQUEST_MANUAL_REVIEW, status);
     assertEquals(ReadingStatus.REQUEST_MANUAL_REVIEW, reading.getFinalReadingStatus());
     assertNull(reading.getFinalReading());
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -700,10 +679,66 @@ class MediaReadingServiceTest {
 
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getFinalReadingStatus());
+    assertNull(reading.getFinalReading());
+
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
+  }
+
+  // Duplicate handling: approved final readings must not create another utility charge.
+  @Test
+  void shouldBlockDuplicateAutoApprovedFinalCharge() throws Exception {
+    UUID settlementId = UUID.randomUUID();
+    MediaReading reading = new MediaReading();
+    reading.setInitialReading(new BigDecimal("100"));
+    reading.setInitialReadingStatus(ReadingStatus.AUTO_APPROVED);
+    reading.setFinalReading(new BigDecimal("150"));
+    reading.setFinalReadingStatus(ReadingStatus.AUTO_APPROVED);
+    reading.setUnitPrice(new BigDecimal("5.00"));
+
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
+        .thenReturn(Optional.of(reading));
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            mediaReadingService.processFinalReadingUpload(
+                settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile));
+
+    verifyNoInteractions(ocrClient);
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
   }
 
   @Test
-  void shouldRequestReuploadWhenFinalOcrReturnsInvalidNumber() throws Exception {
+  void shouldBlockDuplicateManuallyApprovedFinalCharge() {
+    UUID settlementId = UUID.randomUUID();
+    MediaReading reading = new MediaReading();
+    reading.setInitialReading(new BigDecimal("100"));
+    reading.setFinalReading(new BigDecimal("150"));
+    reading.setFinalReadingStatus(ReadingStatus.MANUALLY_APPROVED);
+    reading.setUnitPrice(new BigDecimal("5.00"));
+
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
+        .thenReturn(Optional.of(reading));
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            mediaReadingService.manuallyApproveReading(
+                settlementId,
+                UUID.randomUUID(),
+                UtilityType.WATER,
+                new BigDecimal("160"),
+                ReadingType.FINAL));
+
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
+  }
+
+  // Failure path: invalid OCR result must not change settlement.
+  @Test
+  void shouldNotUpdateSettlementForInvalidFinalOcrValue() throws Exception {
     UUID settlementId = UUID.randomUUID();
     MediaReading reading = new MediaReading();
     reading.setInitialReading(new BigDecimal("100"));
@@ -722,5 +757,85 @@ class MediaReadingServiceTest {
 
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
     assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getFinalReadingStatus());
+    assertNull(reading.getFinalReading());
+
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void shouldNotUpdateSettlementWhenFinalOcrFails() throws Exception {
+    UUID settlementId = UUID.randomUUID();
+    MediaReading reading = new MediaReading();
+    reading.setInitialReading(new BigDecimal("100"));
+    reading.setInitialReadingStatus(ReadingStatus.AUTO_APPROVED);
+    reading.setFinalReadingStatus(ReadingStatus.PENDING);
+
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
+        .thenReturn(Optional.of(reading));
+    when(ocrClient.readMeter(multipartFile)).thenThrow(new RuntimeException("OCR failed"));
+    when(multipartFile.getBytes()).thenReturn(new byte[0]);
+
+    ReadingStatus status =
+        mediaReadingService.processFinalReadingUpload(
+            settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile);
+
+    assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
+    assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getFinalReadingStatus());
+    assertNull(reading.getFinalReading());
+
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void shouldNotUpdateSettlementWhenFinalOcrReturnsNull() throws Exception {
+    UUID settlementId = UUID.randomUUID();
+    MediaReading reading = new MediaReading();
+    reading.setInitialReading(new BigDecimal("100"));
+    reading.setInitialReadingStatus(ReadingStatus.AUTO_APPROVED);
+    reading.setFinalReadingStatus(ReadingStatus.PENDING);
+
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
+        .thenReturn(Optional.of(reading));
+    when(ocrClient.readMeter(multipartFile)).thenReturn(null);
+    when(multipartFile.getBytes()).thenReturn(new byte[0]);
+
+    ReadingStatus status =
+        mediaReadingService.processFinalReadingUpload(
+            settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile);
+
+    assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
+    assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getFinalReadingStatus());
+    assertNull(reading.getFinalReading());
+
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  void shouldNotUpdateSettlementWhenFinalOcrReturnsNullReadingValue() throws Exception {
+    UUID settlementId = UUID.randomUUID();
+    MediaReading reading = new MediaReading();
+    reading.setInitialReading(new BigDecimal("100"));
+    reading.setInitialReadingStatus(ReadingStatus.AUTO_APPROVED);
+    reading.setFinalReadingStatus(ReadingStatus.PENDING);
+
+    when(mediaReadingRepository.findBySettlementIdAndUtilityType(settlementId, UtilityType.WATER))
+        .thenReturn(Optional.of(reading));
+    when(ocrClient.readMeter(multipartFile))
+        .thenReturn(new OcrResponseDto(null, new BigDecimal("0.95")));
+    when(multipartFile.getBytes()).thenReturn(new byte[0]);
+
+    ReadingStatus status =
+        mediaReadingService.processFinalReadingUpload(
+            settlementId, UUID.randomUUID(), UtilityType.WATER, multipartFile);
+
+    assertEquals(ReadingStatus.REQUEST_REUPLOAD, status);
+    assertEquals(ReadingStatus.REQUEST_REUPLOAD, reading.getFinalReadingStatus());
+    assertNull(reading.getFinalReading());
+
+    verify(settlementService, never())
+        .addUtilitySettlementItem(any(), any(), any(), any(), any(), any());
   }
 }

--- a/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementServiceTest.java
+++ b/services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/service/SettlementServiceTest.java
@@ -2,6 +2,7 @@ package io.github.kwatera_project.kwatera.billing_service.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -248,9 +249,14 @@ class SettlementServiceTest {
     settlement.setAmountPaid(BigDecimal.valueOf(500));
     settlement.setBalanceDue(BigDecimal.ZERO);
 
+    when(settlementItemRepository.findBySettlementIdAndType(settlementId, SettlementItemType.WATER))
+        .thenReturn(Optional.empty());
+
     when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
+
     when(settlementItemRepository.save(any(SettlementItem.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
+
     when(settlementItemRepository.existsBySettlementIdAndTypeIn(any(), any())).thenReturn(true);
 
     settlementService.addUtilitySettlementItem(
@@ -265,6 +271,8 @@ class SettlementServiceTest {
     assertEquals(BigDecimal.valueOf(600), settlement.getTotalAmount());
     assertEquals(BigDecimal.valueOf(500), settlement.getAmountPaid());
     assertEquals(BigDecimal.valueOf(100), settlement.getBalanceDue());
+    verify(settlementItemRepository)
+        .findBySettlementIdAndType(settlementId, SettlementItemType.WATER);
     verify(settlementRepository).save(settlement);
   }
 
@@ -278,9 +286,15 @@ class SettlementServiceTest {
     settlement.setAmountPaid(BigDecimal.valueOf(200));
     settlement.setBalanceDue(BigDecimal.valueOf(300));
 
+    when(settlementItemRepository.findBySettlementIdAndType(
+            settlementId, SettlementItemType.ELECTRICITY))
+        .thenReturn(Optional.empty());
+
     when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
+
     when(settlementItemRepository.save(any(SettlementItem.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
+
     when(settlementItemRepository.existsBySettlementIdAndTypeIn(any(), any())).thenReturn(true);
 
     settlementService.addUtilitySettlementItem(
@@ -295,6 +309,9 @@ class SettlementServiceTest {
     assertEquals(BigDecimal.valueOf(600), settlement.getTotalAmount());
     assertEquals(BigDecimal.valueOf(200), settlement.getAmountPaid());
     assertEquals(BigDecimal.valueOf(400), settlement.getBalanceDue());
+
+    verify(settlementItemRepository)
+        .findBySettlementIdAndType(settlementId, SettlementItemType.ELECTRICITY);
     verify(settlementRepository).save(settlement);
   }
 
@@ -359,8 +376,7 @@ class SettlementServiceTest {
             settlementId, SettlementItemType.ACCOMMODATION))
         .thenReturn(Optional.empty());
 
-    io.github.kwatera_project.kwatera.billing_service.dto.ReservationDto reservationDto =
-        new io.github.kwatera_project.kwatera.billing_service.dto.ReservationDto();
+    ReservationDto reservationDto = new ReservationDto();
     reservationDto.setId(reservationId);
     reservationDto.setCurrencyInfo(new CurrencyMetadataDto("PLN", "PLN", BigDecimal.ONE, null));
 
@@ -792,5 +808,34 @@ class SettlementServiceTest {
     // If exchange rate is null, it should fallback to ONE, so amount shouldn't change
     assertEquals(new BigDecimal("40.00"), result.convertedAmount());
     assertEquals("EUR", result.currencyInfo().displayCurrency());
+  }
+
+  @Test
+  void shouldRejectDuplicateUtilityCharge() {
+    UUID settlementId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+
+    SettlementItem existingItem = new SettlementItem();
+    existingItem.setSettlementId(settlementId);
+    existingItem.setType(SettlementItemType.WATER);
+
+    when(settlementItemRepository.findBySettlementIdAndType(settlementId, SettlementItemType.WATER))
+        .thenReturn(Optional.of(existingItem));
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            settlementService.addUtilitySettlementItem(
+                settlementId,
+                unitId,
+                SettlementItemType.WATER,
+                "Water usage",
+                BigDecimal.valueOf(5),
+                BigDecimal.valueOf(20)));
+
+    verify(settlementItemRepository)
+        .findBySettlementIdAndType(settlementId, SettlementItemType.WATER);
+    verify(settlementRepository, never()).findById(any());
+    verify(settlementItemRepository, never()).save(any(SettlementItem.class));
   }
 }


### PR DESCRIPTION
## Summary
This pull request improves final media reading settlement handling by preventing duplicate utility charges for the same settlement and utility type. It also extends tests for OCR failure paths, invalid OCR responses, duplicate handling, and settlement updates.

## Linked issue
Closes #63 

## Scope of changes
- Added duplicate check for water and electricity utility charges.
- Updated media reading tests for final OCR reading cases.
- Added tests to make sure invalid OCR results do not update settlement.
- Added settlement service test for duplicate utility charge protection.

## Testing status

- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Ready for review