### PR TITLE
Update README and CI docs; add Stage 3 demo flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,69 +4,11 @@
 
 The project name expands to Polish:
 
-**K**ompleksowy **W**ebowy **A**systent **T**erminarza, **E**nergii, **R**ezerwacji i **A**dministracji
+**K**ompleksowy **W**ebowy **A**systent **T**erminarza, **E**nergii, **R**ezerwacji i **A**dministracji
 
-## Project Overview
+KWATERA is a semester project focused on building a realistic accommodation management platform rather than a simple CRUD application. The current Stage 3 repository includes guest booking flows, availability handling, role-based access, utility settlement support, payment checkout integration, email notifications, OCR-assisted water meter readings, operational dashboards, and AI-assisted unit price suggestions.
 
-KWATERA is being developed as a semester project focused on building a realistic accommodation management platform rather than a simple CRUD application. The system is intended to support the full reservation lifecycle, including guest booking flows, availability handling, deposit and payment tracking, final settlement of stays, and administrative supervision.
-
-In addition to standard booking features, the project includes AI-assisted modules such as OCR-based meter reading from uploaded images, pricing or occupancy support based on historical reservation data, and weather-informed reservation analysis.
-
-## Planned Scope
-
-The target system is expected to include:
-
-- guest-facing booking and availability search
-- administration and reception workflows
-- reservation status management
-- deposits, payments, balances, and billing
-- utility settlement based on meter readings
-- notifications and reminders
-- reporting and operational dashboards
-- AI OCR for meter reading support
-- predictive analytics for pricing or demand
-- weather-based scoring support
-
-## Target Architecture
-
-The project is planned as a microservice-based solution with:
-
-- Java Spring Boot as the main backend technology
-- a separate Python AI OCR service
-- PostgreSQL as the primary database
-- Spring Cloud Eureka for service discovery
-- Spring Cloud Config Server for centralized configuration
-- JWT-based authentication and authorization in auth-service
-- Docker and Docker Compose for local development and deployment
-- OpenAPI-based API documentation
-
-## Roles
-
-The currently implemented roles in the authentication layer are:
-
-- ADMIN
-- OWNER
-- GUEST
-
-## Repository Workflow
-
-The project is intended to be developed with a team workflow based on:
-
-- feature branches
-- pull requests
-- code review
-- CODEOWNERS
-- GitHub Issues and Kanban-based task tracking
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for issue and pull request workflow conventions.
-
-## Local run
-
-Run the local development environment with Docker Compose:
-
-```bash
-docker compose -f infra/compose/docker-compose.yml up --build
-```
+## Quickstart
 
 ### Local prerequisites
 
@@ -75,7 +17,54 @@ docker compose -f infra/compose/docker-compose.yml up --build
 - Bun
 - Docker with Compose support
 
-### Local quality checks before pull request
+Run the local environment from the repository root:
+
+```bash
+docker compose -f infra/compose/docker-compose.yml up --build
+```
+
+Then open the frontend:
+
+- [http://localhost:5173](http://localhost:5173)
+
+## Target Architecture
+
+The implemented local Stage 3 system is a Docker Compose based microservice application:
+
+- React frontend served through the `frontend` container.
+- Spring Cloud API Gateway routes frontend API calls to backend services.
+- Spring Cloud Config Server loads shared configuration from `config-repo/`.
+- Eureka Service Registry provides service discovery for Spring services.
+- Java Spring Boot services handle authentication, property/catalog data, reservations, billing, settlements, and AI pricing.
+- A Python FastAPI OCR service reads uploaded water meter images.
+- PostgreSQL stores application data and Flyway migrations/seed data are applied by `db-migrations`.
+- Kafka is used by billing and reservation services for settlement status events.
+- Mailpit captures local reservation, settlement, and payment notification emails.
+- OpenAPI/Swagger UI is available on services that include the Springdoc UI dependency, and FastAPI docs are available for the OCR service.
+
+## Roles
+
+The currently implemented roles in the authentication layer are:
+
+- `ADMIN`
+- `OWNER`
+- `GUEST`
+
+Seeded local demo users are created by database migrations. The known demo password is `pass`.
+
+| Role | Email |
+| --- | --- |
+| Admin | `admin@example.com` |
+| Owner | `owner1@example.com`, `owner2@example.com` |
+| Guest | `guest1@example.com`, `guest2@example.com` |
+
+## Repository Workflow
+
+The project is developed with a team workflow based on feature branches, pull requests, code review, CODEOWNERS, GitHub Issues, and Kanban-based task tracking.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for issue and pull request workflow conventions.
+
+## Local Quality Checks Before Pull Request
 
 Before opening a pull request, run local quality checks:
 
@@ -97,65 +86,77 @@ For the frontend it runs:
 - `bun run lint`
 - `bun run build`
 
-JaCoCo coverage reports are generated locally during `verify` and can be opened in a browser from:
+JaCoCo coverage reports are generated locally during `verify` and can be opened in a browser from each Java service under:
 
-- `services/config-server/target/site/jacoco/index.html`
-- `services/service-registry/target/site/jacoco/index.html`
-- `services/reservation-service/target/site/jacoco/index.html`
-
-### Useful URLs after startup:
-
-#### Backend
-- Config Server health: [http://localhost:8888/actuator/health](http://localhost:8888/actuator/health)
-- Eureka dashboard: [http://localhost:8761](http://localhost:8761)
-- Reservation service ping: [http://localhost:8080/api/ping](http://localhost:8080/api/ping)
-- Reservation service health: [http://localhost:8080/actuator/health](http://localhost:8080/actuator/health)
-- OCR service health: [http://localhost:8085/health](http://localhost:8085/health)
-
-#### Frontend
-- Vite dev server for React [http://localhost:5173](http://localhost:5173)
-
-#### Local email testing
-- Mailpit UI: [http://localhost:8025](http://localhost:8025)
-- Mailpit SMTP: `localhost:1025`
-
-Reservation and billing services send development email notifications through Mailpit. Docker Compose
-sets `SPRING_MAIL_HOST=mailpit`, `SPRING_MAIL_PORT=1025`, empty SMTP credentials, and
-`KWATERA_MAIL_FROM=no-reply@kwatera.local`.
-
-To verify emails locally:
-
-```bash
-docker compose -f infra/compose/docker-compose.yml up --build
+```text
+services/<service-name>/target/site/jacoco/index.html
 ```
 
-Open http://localhost:8025, then trigger one of the supported business events. The generated e-mail is sent to the event recipient and should appear in the Mailpit inbox.
+## Useful URLs After Startup
 
-| Event                               | Service               | Recipient source                                                         | Mail subject                 |
-| ----------------------------------- | --------------------- | ------------------------------------------------------------------------ | ---------------------------- |
-| Reservation created                 | `reservation-service` | Authenticated guest e-mail stored as `Reservation.guestEmail`            | `Reservation created`        |
-| Reservation status changed          | `reservation-service` | `Reservation.guestEmail`                                                 | `Reservation status changed` |
-| Settlement created / issued         | `billing-service`     | Guest e-mail resolved from reservation data                              | `Settlement issued`          |
-| Payment / settlement status changed | `billing-service`     | `recipientEmail` propagated through Stripe metadata and webhook handling | `Payment status changed`     |
+### Platform
+
+- Config Server health: [http://localhost:8888/actuator/health](http://localhost:8888/actuator/health)
+- Eureka dashboard: [http://localhost:8761](http://localhost:8761)
+- API Gateway health: [http://localhost:8090/actuator/health](http://localhost:8090/actuator/health)
+- Frontend: [http://localhost:5173](http://localhost:5173)
+
+### Services
+
+- Auth Service login: [http://localhost:8081/api/auth/login](http://localhost:8081/api/auth/login)
+- Property Service: [http://localhost:8083/actuator/health](http://localhost:8083/actuator/health)
+- Reservation Service health: [http://localhost:8080/actuator/health](http://localhost:8080/actuator/health)
+- Reservation Service ping: [http://localhost:8080/api/ping](http://localhost:8080/api/ping)
+- OCR Service health: [http://localhost:8085/health](http://localhost:8085/health)
+- Billing Service: [http://localhost:8086/actuator/health](http://localhost:8086/actuator/health)
+- AI Pricing Service: [http://localhost:8087/actuator/health](http://localhost:8087/actuator/health)
+
+### Infrastructure
+
+- Mailpit UI: [http://localhost:8025](http://localhost:8025)
+- Mailpit SMTP: [smtp://localhost:1025](smtp://localhost:1025)
+- PostgreSQL: [postgresql://localhost:5433/database](postgresql://localhost:5433/database)
+- Kafka broker: `kafka:9092` for local containers; port `9092` is published on the host by Docker Compose.
+
+## Local Email Testing
+
+Reservation and billing services send development email notifications through Mailpit. Docker Compose sets `SPRING_MAIL_HOST=mailpit`, `SPRING_MAIL_PORT=1025`, empty SMTP credentials, and `KWATERA_MAIL_FROM=no-reply@kwatera.local`.
+
+After local startup, generated emails can be inspected in the Mailpit UI at [http://localhost:8025](http://localhost:8025).
+
+| Event | Service | Recipient source | Mail subject |
+| --- | --- | --- | --- |
+| Reservation created | `reservation-service` | Authenticated guest e-mail stored as `Reservation.guestEmail` | `Reservation created` |
+| Reservation status changed | `reservation-service` | `Reservation.guestEmail` | `Reservation status changed` |
+| Settlement created / issued | `billing-service` | Guest e-mail resolved from reservation data | `Settlement issued` |
+| Payment / settlement status changed | `billing-service` | `recipientEmail` propagated through Stripe metadata and webhook handling | `Payment status changed` |
 
 `KWATERA_MAIL_TEST_RECIPIENT` (`guest@kwatera.local` by default) is only a development fallback for flows where no recipient e-mail is available. Fallback usage is logged as a warning.
 
+## Auth / Local Testing
 
-#### Auth / local testing
+Current authentication endpoints through the API Gateway:
 
-Current authentication endpoints:
-- Auth service login: [http://localhost:8081/api/auth/login](http://localhost:8081/api/auth/login)
-- Auth service register: [http://localhost:8081/api/auth/register](http://localhost:8081/api/auth/register)
+- Login: [http://localhost:8090/api/auth/login](http://localhost:8090/api/auth/login)
+- Register: [http://localhost:8090/api/auth/register](http://localhost:8090/api/auth/register)
 
-#### OpenAPI / Swagger UI
+Direct service URLs are also available during local development:
+
+- Auth Service login: [http://localhost:8081/api/auth/login](http://localhost:8081/api/auth/login)
+- Auth Service register: [http://localhost:8081/api/auth/register](http://localhost:8081/api/auth/register)
+
+## OpenAPI / Swagger UI
+
 - Auth Service Swagger UI: [http://localhost:8081/swagger-ui.html](http://localhost:8081/swagger-ui.html)
 - Property Service Swagger UI: [http://localhost:8083/swagger-ui.html](http://localhost:8083/swagger-ui.html)
 - Reservation Service Swagger UI: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)
+- Billing Service Swagger UI: [http://localhost:8086/swagger-ui.html](http://localhost:8086/swagger-ui.html)
+- AI Pricing Service Swagger UI: [http://localhost:8087/swagger-ui.html](http://localhost:8087/swagger-ui.html)
+- OCR Service FastAPI docs: [http://localhost:8085/docs](http://localhost:8085/docs)
 
-> Demo users are seeded through database migrations for local testing.
+## Additional Documentation
 
-## Additional documentation
-
+- [Stage 3 demo flow](docs/stage-3-demo-flow.md)
 - [CI quality pipeline](docs/ci/CI_QUALITY_PIPELINE.md)
 - [Stage 2 API contract and local demo setup](docs/stage-2-api-and-demo.md)
 - [OCR service](services/ocr-service/README.md)

--- a/docs/ci/CI_QUALITY_PIPELINE.md
+++ b/docs/ci/CI_QUALITY_PIPELINE.md
@@ -1,50 +1,60 @@
 [BACK TO README.MD](../../README.md)
+
 # CI Quality Pipeline
 
-This document describes the quality pipeline used in the KWATERA repository and explains what is executed in CI for both the frontend application and the backend modules.
+This document describes the current quality pipeline used in the KWATERA repository.
 
 ## Purpose
 
 The CI pipeline verifies code quality and build stability across the repository.
 
 Its goals are:
+
 - keep formatting and static analysis consistent across modules,
 - detect build or test regressions early,
-- run SonarCloud analysis for onboarded backend modules,
-- make test and analysis reports available as downloadable workflow artifacts where applicable.
+- run SonarCloud analysis where the workflow enables it,
+- make backend reports available as downloadable workflow artifacts where applicable.
 
-## Workflow scope
+## Workflow Scope
 
 The main CI workflow is defined in:
 
 - `.github/workflows/ci.yml`
 
 It runs on:
+
 - `push` to `main`
-- `pull_request` targeting `main` for:
-   - `opened`
-   - `synchronize`
-   - `reopened`
+- `pull_request` targeting `main` for `opened`, `synchronize`, and `reopened`
 
-The workflow currently contains two quality paths:
-- a dedicated frontend job for the application under `frontend/`,
-- a backend matrix job for Java modules under `services/`.
+The workflow currently contains three quality paths:
 
-The backend part of the workflow uses a matrix strategy, so each backend module is processed independently.
+- a frontend job for the application under `frontend/`,
+- a Python job for `services/ocr-service`,
+- a Java backend matrix job for Maven modules under `services/<module-name>`.
 
-## Components covered by CI
+## Components Covered By CI
 
-### Frontend application
+### Frontend Application
 
-The frontend quality job covers the application located in:
+The frontend quality job covers:
 
 ```text
 frontend/
 ```
 
-### Backend modules covered by the matrix
+### Python OCR Service
 
-At the moment, the backend CI matrix covers:
+The Python quality job covers:
+
+```text
+services/ocr-service/
+```
+
+`ocr-service` is not part of the Java backend matrix because it is a Python FastAPI service.
+
+### Java Backend Matrix
+
+The Java backend CI matrix covers:
 
 - `api-gateway`
 - `auth-service`
@@ -53,187 +63,124 @@ At the moment, the backend CI matrix covers:
 - `reservation-service`
 - `service-registry`
 - `db-migrations`
+- `billing-service`
+- `ai-pricing-service`
 
-Each backend module is executed from its own working directory:
+Each Java module is executed from:
 
 ```text
 services/<module-name>
 ```
 
-## What CI runs for the frontend
+## What CI Runs For The Frontend
 
-For the frontend job, CI executes the following steps:
+For the frontend job, CI executes:
 
-1. **Checkout repository**
+1. Checkout repository.
+2. Set up Bun with `oven-sh/setup-bun@v2`.
+3. Install dependencies:
 
-2. **Set up Bun**
-   - installs the Bun runtime used by the frontend toolchain
+   ```bash
+   bun install --frozen-lockfile
+   ```
 
-3. **Install dependencies**
-   - runs:
-     ```bash
-     bun install --frozen-lockfile
-     ```
-   - verifies that the lockfile is valid and dependencies install correctly
+4. Run lint:
 
-4. **Run lint**
-   - runs:
-     ```bash
-     bun run lint
-     ```
-   - checks frontend code quality against the configured linting rules
+   ```bash
+   bun run lint
+   ```
 
-5. **Build frontend**
-   - runs:
-     ```bash
-     bun run build
-     ```
-   - verifies that the frontend builds successfully for production
+5. Build frontend:
 
-## What CI runs for each backend module
+   ```bash
+   bun run build
+   ```
 
-For every backend module in the matrix, CI executes the following steps:
+The frontend job does not upload dedicated workflow report artifacts.
 
-1. **Checkout repository**
-   - uses full git history with `fetch-depth: 0`
-   - this is important for SonarCloud branch and pull request analysis
+## What CI Runs For OCR Service
 
-2. **Set up Java 25**
-   - installs Temurin JDK 25
-   - enables Maven dependency caching
+For `services/ocr-service`, CI executes:
 
-3. **Cache Sonar packages**
-   - caches Sonar scanner data in `~/.sonar/cache`
-   - reduces repeated download time between workflow runs
+1. Checkout repository with `fetch-depth: 0`.
+2. Set up Python 3.12 with pip caching.
+3. Install development dependencies:
 
-4. **Make Maven Wrapper executable**
-   - runs:
-     ```bash
-     chmod +x mvnw
-     ```
+   ```bash
+   python -m pip install --upgrade pip
+   pip install -r requirements-dev.txt
+   ```
 
-5. **Check formatting**
-   - runs:
-     ```bash
-     ./mvnw -B -ntp spotless:check
-     ```
-   - verifies whether the code follows the configured formatting rules
-   - does not modify files in CI
-   - fails the job if formatting is incorrect
+4. Run Ruff lint:
 
-6. **Build, test and generate coverage**
-   - runs:
-     ```bash
-     ./mvnw -B -ntp clean verify
-     ```
-   - performs a clean build
-   - runs tests included in the Maven lifecycle
-   - generates coverage and test outputs if configured in the module
+   ```bash
+   ruff check .
+   ```
 
-7. **Run SpotBugs**
-   - runs:
-     ```bash
-     ./mvnw -B -ntp spotbugs:check
-     ```
-   - performs static analysis for potential bug patterns in Java code
-   - fails the job if SpotBugs reports issues above the accepted threshold
+5. Check Ruff formatting:
 
-8. **Run SonarCloud analysis**
-   - executed only when `sonar_enabled: true` for the module
-   - runs:
-     ```bash
-     ./mvnw -B -ntp org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar \
-       -Dsonar.organization=${SONAR_ORGANIZATION} \
-       -Dsonar.projectKey=<module-project-key> \
-       -Dsonar.host.url=https://sonarcloud.io \
-       -Dsonar.qualitygate.wait=true
-     ```
-   - publishes code analysis results to SonarCloud
-   - waits for the Quality Gate result before finishing the step
+   ```bash
+   ruff format --check .
+   ```
 
-9. **Upload reports**
-   - uploads workflow artifacts even if the job fails
-   - attempts to upload report files generated by the current module
-   - supported report paths include:
-      - JaCoCo reports
-      - Surefire reports
-      - Failsafe reports
-      - SpotBugs XML report
-   - some of these files may be missing if a module does not generate them
+6. Run pytest with coverage:
 
-## SonarCloud configuration
+   ```bash
+   pytest --cov=app --cov-report=xml:coverage.xml --cov-report=term-missing -q
+   ```
 
-KWATERA uses SonarCloud in monorepo mode for backend modules.
+7. Build the OCR Docker image:
 
-Each onboarded backend module must have:
-- its own SonarCloud project,
-- its own unique `sonar.projectKey`,
-- a matching entry in the CI matrix.
+   ```bash
+   docker build -f Dockerfile -t kwatera-ocr-service:ci ../..
+   ```
 
-Example key format used in this repository:
+8. Run SonarQube Cloud analysis with `projectBaseDir: services/ocr-service`.
 
-```text
-kwatera-project_KWATERA_<module-name>
-```
+## What CI Runs For Each Java Backend Module
 
-Examples:
-- `kwatera-project_KWATERA_api-gateway`
-- `kwatera-project_KWATERA_auth-service`
-- `kwatera-project_KWATERA_config-server`
-- `kwatera-project_KWATERA_property-service`
-- `kwatera-project_KWATERA_reservation-service`
-- `kwatera-project_KWATERA_service-registry`
-- `kwatera-project_KWATERA_db-migrations`
+For every Java module in the matrix, CI executes:
 
-## Meaning of matrix fields
+1. Checkout repository with `fetch-depth: 0`.
+2. Set up Temurin Java 25 with Maven dependency caching.
+3. Cache Sonar scanner packages under `~/.sonar/cache`.
+4. Make Maven Wrapper executable:
 
-Each backend matrix entry contains:
+   ```bash
+   chmod +x mvnw
+   ```
 
-- `service`
-   - module directory name under `services/`
+5. Check formatting:
 
-- `sonar_enabled`
-   - enables or disables SonarCloud analysis for the module
+   ```bash
+   ./mvnw -B -ntp spotless:check
+   ```
 
-- `sonar_project_key`
-   - SonarCloud project key used by the Maven Sonar scanner
+6. Build, test, and generate coverage:
 
-## Requirements for adding a new backend module to CI
+   ```bash
+   ./mvnw -B -ntp clean verify
+   ```
 
-A backend module should be added to the CI matrix only if it is independently buildable in its own directory.
+7. Run SpotBugs:
 
-Minimum requirements:
-- directory exists under `services/<module-name>`
-- contains its own `pom.xml`
-- contains its own `mvnw`
-- can successfully run:
-   - `spotless:check`
-   - `clean verify`
-   - `spotbugs:check`
+   ```bash
+   ./mvnw -B -ntp spotbugs:check
+   ```
 
-If SonarCloud should also be enabled, the module must first be onboarded in SonarCloud and assigned a valid unique project key.
+8. Run SonarQube Cloud analysis when `sonar_enabled: true`:
 
-## Recommended procedure for onboarding a new backend module
+   ```bash
+   ./mvnw -B -ntp org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar \
+     -Dsonar.organization=${SONAR_ORGANIZATION} \
+     -Dsonar.projectKey=<module-project-key> \
+     -Dsonar.host.url=https://sonarcloud.io \
+     -Dsonar.qualitygate.wait=true
+   ```
 
-1. Create or verify the module under `services/<module-name>`.
-2. Ensure the module builds locally with Maven Wrapper.
-3. Add the module to the CI matrix with:
-   - `sonar_enabled: false`
-   - empty `sonar_project_key`
-4. Verify that non-Sonar quality checks pass in CI.
-5. Create a dedicated SonarCloud monorepo project for the module.
-6. Update the CI matrix:
-   - set `sonar_enabled: true`
-   - set the correct `sonar_project_key`
-7. Open a pull request and verify:
-   - workflow success,
-   - SonarCloud analysis,
-   - PR decoration,
-   - Quality Gate result.
+9. Upload reports with `actions/upload-artifact@v4`.
 
-## Reports produced by CI
-
-For backend modules, the workflow attempts to upload the following report locations when they are present:
+The report upload step uses these paths:
 
 ```text
 services/<module>/target/site/jacoco/**
@@ -242,16 +189,50 @@ services/<module>/target/failsafe-reports/**
 services/<module>/target/spotbugsXml.xml
 ```
 
-Not every backend module generates every report type. The uploaded artifacts may include:
-- test execution results,
-- integration test output,
-- coverage data,
-- SpotBugs findings.
+Not every module generates every report type.
 
-The frontend job currently verifies install, lint and build, but does not upload dedicated workflow report artifacts.
+## SonarCloud Configuration
+
+The current Java matrix sets `sonar_enabled: true` for every Java module listed below:
+
+| Module | SonarCloud project key |
+| --- | --- |
+| `api-gateway` | `kwatera-project_KWATERA_api-gateway` |
+| `auth-service` | `kwatera-project_KWATERA_auth-service` |
+| `config-server` | `kwatera-project_KWATERA_config-server` |
+| `property-service` | `kwatera-project_KWATERA_property-service` |
+| `reservation-service` | `kwatera-project_KWATERA_reservation-service` |
+| `service-registry` | `kwatera-project_KWATERA_service-registry` |
+| `db-migrations` | `kwatera-project_KWATERA_db-migrations` |
+| `billing-service` | `kwatera-project_KWATERA_billing-service` |
+| `ai-pricing-service` | `kwatera-project_KWATERA_ai-pricing-service` |
+
+The OCR service also runs SonarQube Cloud analysis through the Python quality job using the `services/ocr-service` project base directory.
+
+No Java matrix entry currently has `sonar_enabled: false`.
+
+## Meaning Of Java Matrix Fields
+
+Each Java backend matrix entry contains:
+
+- `service`: module directory name under `services/`.
+- `sonar_enabled`: controls whether the conditional SonarQube Cloud Maven step runs.
+- `sonar_project_key`: SonarCloud project key used by the Maven Sonar scanner.
+
+## Reports Produced By CI
+
+For Java backend modules, the workflow attempts to upload:
+
+- JaCoCo coverage reports,
+- Surefire test reports,
+- Failsafe integration test reports,
+- SpotBugs XML reports.
+
+For the OCR service, pytest generates `coverage.xml` inside `services/ocr-service`, but the current workflow does not upload it as an artifact.
 
 ## Notes
 
-- `db-migrations` is included in the quality pipeline as a technical module, even though it is not treated as a business microservice.
-- SonarCloud onboarding should be completed before enabling Sonar for a newly added backend module.
-- The quality pipeline is intentionally split into frontend and backend paths, while the backend path remains module-based so failures in one backend module do not automatically block analysis of all others.
+- `db-migrations` is included in the Java quality matrix as a technical Maven module.
+- `billing-service` and `ai-pricing-service` are Stage 3 Java services and are covered by the current Java matrix.
+- `ocr-service` has its own Python quality path instead of being listed as a Java backend module.
+- The backend matrix uses `fail-fast: false`, so one module failure does not stop the other matrix entries from running.

--- a/docs/stage-3-demo-flow.md
+++ b/docs/stage-3-demo-flow.md
@@ -127,6 +127,34 @@ The dashboard uses:
 
 The owner units page calls the AI Pricing Service through the API Gateway at `/api/predict/price/property/{propertyId}/unit/{unitId}`.
 
+### Try AI pricing directly through Swagger
+
+You can also test dynamic pricing directly through the AI Pricing Service Swagger UI.
+
+1. Open AI Pricing Service Swagger UI:
+
+    * http://localhost:8087/swagger-ui.html
+
+2. Find the prediction endpoint:
+
+    * `GET /api/predict/price/property/{propertyId}/unit/{unitId}`
+    * `GET /api/predict/price/property/{propertyId}/unit/{unitId}/date/{date}`
+
+3. Use a seeded or existing `propertyId` and `unitId`.
+
+4. First execute the endpoint without `date`. This uses the current local date on the backend.
+
+5. Then execute the endpoint with different `date` values in `YYYY-MM-DD` format, for example:
+
+    * `2026-06-15`
+    * `2026-07-15`
+    * `2026-08-15`
+
+6. Compare returned predicted prices and observe how the model output changes for different dates.
+
+The endpoint with `/date/{date}` is useful for demo purposes because it allows checking the same property/unit pair for different stay dates without changing frontend state or database data.
+
+
 ## Current Stage 3 gaps visible in the repository
 
 - Weather-related output is not exposed by the current frontend routes or backend controllers.

--- a/docs/stage-3-demo-flow.md
+++ b/docs/stage-3-demo-flow.md
@@ -1,0 +1,134 @@
+# Stage 3 Demo Flow
+
+This checklist shows how to manually observe the Stage 3 deliverables in the current repository. It describes implemented UI/API behavior only.
+
+## 1. Start the local environment
+
+From the repository root:
+
+```bash
+docker compose -f infra/compose/docker-compose.yml up --build
+```
+
+Open the frontend:
+
+- [http://localhost:5173](http://localhost:5173)
+
+Useful support pages:
+
+- Eureka: [http://localhost:8761](http://localhost:8761)
+- Mailpit: [http://localhost:8025](http://localhost:8025)
+- OCR health: [http://localhost:8085/health](http://localhost:8085/health)
+
+## 2. Log in with seeded demo users
+
+The database migrations seed demo users. Use the password `pass`.
+
+| Role | Email |
+| --- | --- |
+| Admin | `admin@example.com` |
+| Owner | `owner1@example.com` or `owner2@example.com` |
+| Guest | `guest1@example.com` or `guest2@example.com` |
+
+If the seeded database was replaced, create a user through the Sign Up page or call `POST /api/auth/register` through the API Gateway at `http://localhost:8090`.
+
+## 3. Browse and create a reservation
+
+1. Open [http://localhost:5173/catalog](http://localhost:5173/catalog).
+2. Open a property from the catalog.
+3. Choose stay dates in the availability calendar.
+4. Select an available unit and click `Book these dates`.
+5. Observe that the frontend calls the reservation API and then tries to create a billing checkout session.
+
+Notes:
+
+- Reservation creation is implemented for authenticated guests.
+- Checkout redirection depends on valid Stripe environment variables in the local Compose environment.
+- Seeded reservations are available immediately after migrations if you only need to observe reservation details.
+
+## 4. Observe reservation administration
+
+1. Log in as `admin@example.com` or `owner1@example.com`.
+2. Open the profile menu.
+3. Click `Reservations`.
+4. Review the reservation list, status filter, and reservation detail links.
+5. Change a reservation status from the available admin controls.
+6. Open Mailpit and verify the reservation status email when the status change sends one.
+
+The admin/owner reservation list is implemented at `/admin/reservations`.
+
+## 5. Observe settlements and payments
+
+1. Log in as a guest and open `My Reservations`, or log in as an admin/owner and open `Reservations`.
+2. Open a reservation detail page.
+3. Click `View Settlement`.
+4. Review settlement status, totals, line items, currency display, and payment buttons where settlement items are present.
+5. If Stripe is configured locally, click a payment button to trigger checkout.
+6. If Stripe is not configured, use the seeded settlement/payment data to observe statuses in the settlement page and dashboard.
+
+Seeded settlements and payment transactions are created by the migration files under `services/db-migrations/src/main/resources/db/migration/`.
+
+## 6. Observe OCR water meter reading flow
+
+1. Log in as a guest with a reservation that has a settlement.
+2. Open `My Reservations`.
+3. Click `Water Meter` on a reservation card when the link is shown.
+4. Upload a water meter image for the check-in reading.
+5. Observe the returned reading status and, when present, the confidence score.
+6. After an initial reading is approved, upload a check-out reading.
+
+The guest meter page shows reading status, reading value, confidence, and source for check-in and check-out readings.
+
+Limitations to keep in mind:
+
+- The OCR container expects the YOLO model file described in [services/ocr-service/README.md](../services/ocr-service/README.md). Without the model, OCR image processing may not complete successfully.
+- The implemented fallback states include `REQUEST_REUPLOAD` and `REQUEST_MANUAL_REVIEW`.
+
+## 7. Review manual OCR confirmation
+
+1. Log in as `admin@example.com` or an owner account.
+2. Open `Reservations`.
+3. Click `Meter Readings` for a reservation where the link is shown.
+4. Review uploaded meter photos, OCR values, confidence scores, and statuses.
+5. If a reading is in `REQUEST_MANUAL_REVIEW`, enter a corrected value and approve it.
+
+The admin/owner review page is implemented at `/admin/settlements/:settlementId/meter-readings`.
+
+## 8. Verify generated emails
+
+Open [http://localhost:8025](http://localhost:8025) after triggering reservation, settlement, or payment-related actions.
+
+Implemented local email events include:
+
+- reservation created,
+- reservation status changed,
+- settlement created / issued,
+- payment or settlement status changed.
+
+## 9. View dashboard output
+
+1. Log in as `admin@example.com` or an owner account.
+2. Open the profile menu.
+3. Click `Dashboard`.
+4. Review reservation metrics, billing metrics, settlement payment status, revenue, and unpaid balance widgets.
+
+The dashboard uses:
+
+- reservation metrics from `/api/v1/admin/dashboard/reservations`,
+- billing metrics from `/api/v1/admin/dashboard/billing`.
+
+## 10. View AI pricing output
+
+1. Log in as an owner account.
+2. Open the profile menu.
+3. Click `Manage properties`.
+4. Open `Manage Units` for a property.
+5. Review the `Suggested price` value on each unit card.
+
+The owner units page calls the AI Pricing Service through the API Gateway at `/api/predict/price/property/{propertyId}/unit/{unitId}`.
+
+## Current Stage 3 gaps visible in the repository
+
+- Weather-related output is not exposed by the current frontend routes or backend controllers.
+- Add/edit/delete buttons on owner property and unit management pages are visible UI controls, but the repository does not include implemented create/update/delete behavior for those controls.
+- Payment checkout requires local Stripe configuration; otherwise use seeded payment and settlement data for observation.


### PR DESCRIPTION
## Summary

Revamps Stage 3 documentation so the repository README, demo instructions and CI quality pipeline reflect the current implemented state of KWATERA after the May milestone.

This PR is documentation-only. It removes outdated planned-scope wording, adds a practical quickstart, documents current local services and URLs, adds a Stage 3 demo checklist, and updates CI documentation for the current frontend, OCR and Java backend quality paths.

## Linked issue

Closes #75

## Scope of changes

* Updated `README.md` with Stage 3 quickstart, local prerequisites, Docker Compose startup, current architecture, service URLs, seeded demo users, repository workflow, local quality checks, Mailpit notes and documentation links.
* Added `docs/stage-3-demo-flow.md` with a practical step-by-step checklist for verifying Stage 3 deliverables, including reservations, settlements, OCR meter readings, email testing, dashboard and AI pricing.
* Updated `docs/ci/CI_QUALITY_PIPELINE.md` to document the frontend job, Python OCR CI job, Java backend matrix including `billing-service` and `ai-pricing-service`, SonarCloud usage and report upload paths.

## Testing status

- [x] Existing tests pass

## Checklist

* [x] PR title is clear and meaningful
* [x] Linked issue is included
* [x] Scope matches the issue
* [x] No unrelated changes were added
* [x] Documentation updated if needed
* [x] Ready for review
