### PR TITLE
111 feature restore confirmed button for owner in reservations panel

### DIFF
--- a/frontend/src/components/AdminReservationList.tsx
+++ b/frontend/src/components/AdminReservationList.tsx
@@ -254,7 +254,7 @@ export default function AdminReservationList() {
                                             <button
                                                 disabled={!isConfirmEnabled}
                                                 onClick={() => handleStatusChange(res.id, 'CONFIRMED')}
-                                                className="px-3 py-1.5 text-xs font-semibold rounded-lg border border-transparent transition-all inline-flex items-center justify-center gap-1 shrink-0 text-emerald-700 bg-emerald-50 hover:bg-emerald-100 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:border-gray-200 cursor-pointer"
+                                                className="px-3 py-1.5 text-xs font-semibold rounded-lg border transition-all inline-flex items-center justify-center gap-1 shrink-0 text-gray-700 bg-white border-gray-300 hover:bg-gray-50 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:border-gray-200 cursor-pointer disabled:cursor-not-allowed"
                                             >
                                                 Confirm
                                             </button>

--- a/frontend/src/components/AdminReservationList.tsx
+++ b/frontend/src/components/AdminReservationList.tsx
@@ -198,6 +198,7 @@ export default function AdminReservationList() {
                     <tbody className="divide-y divide-[#DACDCA]/60 bg-white">
                         {filteredReservations.map((res) => {
                             const isMeterReadingsEnabled = !!settlementIds[res.id] && !!unitIds[res.id] && (res.status === "CONFIRMED" || res.status === "COMPLETED");
+                            const isConfirmEnabled = res.status === "PENDING";
                             const isCompleteEnabled = res.status === "CONFIRMED";
                             const isCancelEnabled = res.status === "PENDING" || res.status === "CONFIRMED";
 
@@ -227,7 +228,6 @@ export default function AdminReservationList() {
                                     </td>
                                     <td className="px-6 py-4 text-sm text-center">
                                         <div className="flex flex-wrap justify-center items-center gap-2">
-                                            {/* 1. View Details (always active, solid primary styling) */}
                                             <Link
                                                 to={`/reservations/${res.id}`}
                                                 className="px-3 py-1.5 text-xs font-semibold text-white bg-[#42211D] hover:bg-[#321815] rounded-lg transition-all shadow-sm active:scale-95 inline-flex items-center justify-center gap-1 shrink-0 cursor-pointer"
@@ -235,7 +235,6 @@ export default function AdminReservationList() {
                                                 View Details
                                             </Link>
 
-                                            {/* 2. Meter Readings (always rendered, conditionally disabled with Tailwind classes) */}
                                             {isMeterReadingsEnabled ? (
                                                 <Link
                                                     to={`/admin/settlements/${settlementIds[res.id]}/meter-readings?unitId=${unitIds[res.id]}`}
@@ -252,7 +251,14 @@ export default function AdminReservationList() {
                                                 </button>
                                             )}
 
-                                            {/* 3. Complete (always rendered, conditionally disabled with Tailwind classes) */}
+                                            <button
+                                                disabled={!isConfirmEnabled}
+                                                onClick={() => handleStatusChange(res.id, 'CONFIRMED')}
+                                                className="px-3 py-1.5 text-xs font-semibold rounded-lg border border-transparent transition-all inline-flex items-center justify-center gap-1 shrink-0 text-emerald-700 bg-emerald-50 hover:bg-emerald-100 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:border-gray-200 cursor-pointer"
+                                            >
+                                                Confirm
+                                            </button>
+
                                             <button
                                                 disabled={!isCompleteEnabled}
                                                 onClick={() => handleStatusChange(res.id, 'COMPLETED')}
@@ -261,7 +267,6 @@ export default function AdminReservationList() {
                                                 Complete
                                             </button>
 
-                                            {/* 4. Cancel (always rendered, conditionally disabled with Tailwind classes) */}
                                             <button
                                                 disabled={!isCancelEnabled}
                                                 onClick={() => handleStatusChange(res.id, 'CANCELLED')}


### PR DESCRIPTION
## Summary
This pull request introduces the missing **Confirm** button in the Admin Reservation List panel (`/admin/reservations`). It enables administrators and owners to approve pending guest reservations, changing their status from `PENDING` to `CONFIRMED`.

## Linked issue
Closes #111 

## Scope of changes
- **`AdminReservationList.tsx`**:
  - Defined the `isConfirmEnabled` state rule (`res.status === "PENDING"`).
  - Implemented the "Confirm" action button within the table rows, styled identically to the "Complete" button for unified layout aesthetics.
  - Bound the click event to invoke the status update endpoint through the existing `handleStatusChange(res.id, 'CONFIRMED')` routine.
  - Removed old inline comments (numbered 1 to 5) in the JSX button section to keep the codebase clean and maintainable.

## Testing status
- [x] Tested locally
- [x] Existing tests pass

## Checklist
- [x] PR title is clear and meaningful
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] Ready for review