### PR TITLE
Add final flow polish issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/final-flow-polish.yml
+++ b/.github/ISSUE_TEMPLATE/final-flow-polish.yml
@@ -1,0 +1,34 @@
+name: Final flow polish
+description: Small issue for closing missing or broken application flows
+title: "[Polish] "
+body:
+  - type: textarea
+    id: what_to_complete
+    attributes:
+      label: What needs to be completed?
+      description: Briefly describe what is missing, broken, or unfinished.
+    validations:
+      required: true
+
+  - type: textarea
+    id: where
+    attributes:
+      label: Where?
+      description: Role, screen, route, or flow, e.g. OWNER -> Manage properties.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      description: Optional. What should happen after the fix?
+
+  - type: textarea
+    id: definition_of_done
+    attributes:
+      label: Definition of Done
+      description: Optional. Add only what is useful.
+      value: |
+        - [ ] Fixed
+        - [ ] Manually verified


### PR DESCRIPTION
## Summary

Adds a new lightweight GitHub issue template for small final flow polish tasks, such as missing actions, broken navigation, unfinished UI flows, or minor demo-blocking gaps.

## Linked issue

Closes #113

## Scope of changes

* Added `.github/ISSUE_TEMPLATE/final-flow-polish.yml`
* Added minimal fields for reporting flow polish tasks
* Kept expected behavior and Definition of Done optional for faster issue creation

## Checklist

* [x] PR title is clear and meaningful
* [x] Linked issue is included
* [x] Scope matches the issue
* [x] No unrelated changes were added
* [x] Ready for review
