### PR TITLE
Change location to city

### DIFF
--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -5,7 +5,7 @@ import DatePicker from 'react-datepicker';
 import SharedDatePicker from "../SharedDatePicker";
 
 export default function HeroSection() {
-    const [location, setLocation] = useState('');
+    const [city, setCity] = useState('');
     const [checkIn, setCheckIn] = useState<Date | null>(null);
     const [checkOut, setCheckOut] = useState<Date | null>(null);
     const [guests, setGuests] = useState('2');
@@ -14,7 +14,7 @@ export default function HeroSection() {
 
     const handleSearch = () => {
         const params = new URLSearchParams();
-        if (location) params.append('location', location);
+        if (city) params.append('city', city);
         if (checkIn) params.append('checkIn', checkIn.toISOString().split('T')[0]);
         if (checkOut) params.append('checkOut', checkOut.toISOString().split('T')[0]);
         if (guests) params.append('guests', guests);
@@ -46,14 +46,14 @@ export default function HeroSection() {
                     <div className="relative z-[9999] w-full max-w-5xl bg-white rounded-3xl md:rounded-full shadow-xl border border-[#DACDCA] p-3 flex flex-col md:flex-row items-center divide-y md:divide-y-0 md:divide-x divide-gray-200 gap-y-2 md:gap-y-0">
 
                         <div className="flex-1 w-full px-6 py-3 flex flex-col items-start hover:bg-gray-50 rounded-full transition-colors relative group z-[100]">
-                            <label htmlFor="location" className="text-xs font-bold text-title uppercase tracking-wider mb-1 cursor-pointer flex items-center gap-1.5">
+                            <label htmlFor="city" className="text-xs font-bold text-title uppercase tracking-wider mb-1 cursor-pointer flex items-center gap-1.5">
                                 <MapPin size={14} className="text-[rgb(var(--color-burgundy))]" /> Location
                             </label>
                             <input
                                 type="text"
-                                id="location"
-                                value={location}
-                                onChange={(e) => setLocation(e.target.value)}
+                                id="city"
+                                value={city}
+                                onChange={(e) => setCity(e.target.value)}
                                 className="w-full bg-transparent text-title placeholder-gray-400 focus:outline-none font-medium text-lg"
                                 placeholder="Warszawa, Zakopane..."
                                 autoComplete="off"

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -47,7 +47,7 @@ export default function HeroSection() {
 
                         <div className="flex-1 w-full px-6 py-3 flex flex-col items-start hover:bg-gray-50 rounded-full transition-colors relative group z-[100]">
                             <label htmlFor="city" className="text-xs font-bold text-title uppercase tracking-wider mb-1 cursor-pointer flex items-center gap-1.5">
-                                <MapPin size={14} className="text-[rgb(var(--color-burgundy))]" /> Location
+                                <MapPin size={14} className="text-[rgb(var(--color-burgundy))]" /> City
                             </label>
                             <input
                                 type="text"

--- a/frontend/src/components/landing/TopPropertiesSection.tsx
+++ b/frontend/src/components/landing/TopPropertiesSection.tsx
@@ -118,7 +118,7 @@ export default function TopPropertiesSection({ properties = [] }: TopPropertiesP
                     </h3>
                     <div className="flex items-center gap-1.5 text-details font-medium">
                       <MapPin size={15} />
-                      <span className="text-sm">{property.country || property.city || 'Poland'}</span>
+                      <span className="text-sm">{property.city || property.country || 'Poland'}</span>
                     </div>
                   </div>
                   <div className="text-right whitespace-nowrap">

--- a/frontend/src/components/landing/TopPropertiesSection.tsx
+++ b/frontend/src/components/landing/TopPropertiesSection.tsx
@@ -9,8 +9,13 @@ interface Property {
     id: string;
     title?: string;
     name?: string;
-    location?: string;
+    country?: string;
     city?: string;
+    postalCode?: string;
+    street?:  string;
+    streetNumber?:  string;
+    latitude?: number;
+    longitude?: number;
     price?: number;
     pricePerNight?: number;
     rating?: number;
@@ -113,7 +118,7 @@ export default function TopPropertiesSection({ properties = [] }: TopPropertiesP
                     </h3>
                     <div className="flex items-center gap-1.5 text-details font-medium">
                       <MapPin size={15} />
-                      <span className="text-sm">{property.location || property.city || 'Poland'}</span>
+                      <span className="text-sm">{property.country || property.city || 'Poland'}</span>
                     </div>
                   </div>
                   <div className="text-right whitespace-nowrap">

--- a/frontend/src/pages/ReservationDetailsPage.tsx
+++ b/frontend/src/pages/ReservationDetailsPage.tsx
@@ -104,7 +104,7 @@ export default function ReservationDetailsPage() {
                                 </p>
                                 {reservation.city && (
                                     <p className="text-sm font-semibold text-gray-600 mt-1 flex items-center gap-1">
-                                        <span>Location:</span>
+                                        <span>City:</span>
                                         <span className="text-[#1A1A1A]">{reservation.city}</span>
                                     </p>
                                 )}

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/BusinessDateProvider.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/BusinessDateProvider.java
@@ -1,0 +1,21 @@
+package io.github.kwatera_project.kwatera.reservation_service.service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BusinessDateProvider {
+
+  private final ZoneId businessZone;
+
+  public BusinessDateProvider(
+      @Value("${kwatera.business-zone:Europe/Warsaw}") String businessZone) {
+    this.businessZone = ZoneId.of(businessZone);
+  }
+
+  public LocalDate today() {
+    return LocalDate.now(businessZone);
+  }
+}

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -9,7 +9,6 @@ import io.github.kwatera_project.kwatera.reservation_service.repository.Reservat
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -33,14 +32,14 @@ public class ReservationService {
   private final RestTemplate restTemplate;
   private final NbpExchangeRateClient nbpExchangeRateClient;
   private final EmailNotificationService emailNotificationService;
+  private final BusinessDateProvider businessDateProvider;
 
   public AvailabilityDto checkAvailability(UUID unitId, LocalDate from, LocalDate to) {
     if (from == null || to == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Dates are required");
     }
 
-    ZoneId userTimeZone = ZoneId.of("UTC");
-    LocalDate today = LocalDate.now(userTimeZone);
+    LocalDate today = businessDateProvider.today();
 
     if (from.isBefore(today)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Date is in the past");
@@ -417,8 +416,7 @@ public class ReservationService {
   public ReservationMetricsDto getDashboardReservationMetrics(
       LocalDate startDate, LocalDate endDate, UUID ownerId, boolean isAdmin) {
 
-    ZoneId userTimeZone = ZoneId.of("UTC");
-    LocalDate today = LocalDate.now(userTimeZone);
+    LocalDate today = businessDateProvider.today();
 
     LocalDate start = (startDate != null) ? startDate : today.withDayOfMonth(1);
     LocalDate end =

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -307,8 +307,8 @@ public class ReservationService {
           PropertyDetailsDto propertyDto =
               restTemplate.getForObject(propertyUrl, PropertyDetailsDto.class);
           if (propertyDto != null) {
-            if (propertyDto.location() != null) {
-              city = propertyDto.location();
+            if (propertyDto.city() != null) {
+              city = propertyDto.city();
             }
             if (propertyDto.ownerId() != null) {
               UUID ownerId = propertyDto.ownerId();
@@ -471,5 +471,5 @@ public class ReservationService {
 
   record UnitDetailsDto(UUID propertyId, String name) {}
 
-  record PropertyDetailsDto(String title, String location, UUID ownerId) {}
+  record PropertyDetailsDto(String title, String city, UUID ownerId) {}
 }

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -9,6 +9,7 @@ import io.github.kwatera_project.kwatera.reservation_service.repository.Reservat
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -37,7 +38,11 @@ public class ReservationService {
     if (from == null || to == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Dates are required");
     }
-    if (from.isBefore(LocalDate.now())) {
+
+    ZoneId userTimeZone = ZoneId.of("UTC");
+    LocalDate today = LocalDate.now(userTimeZone);
+
+    if (from.isBefore(today)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Date is in the past");
     }
     if (!from.isBefore(to)) {
@@ -412,11 +417,14 @@ public class ReservationService {
   public ReservationMetricsDto getDashboardReservationMetrics(
       LocalDate startDate, LocalDate endDate, UUID ownerId, boolean isAdmin) {
 
-    LocalDate start = (startDate != null) ? startDate : LocalDate.now().withDayOfMonth(1);
+    ZoneId userTimeZone = ZoneId.of("UTC");
+    LocalDate today = LocalDate.now(userTimeZone);
+
+    LocalDate start = (startDate != null) ? startDate : today.withDayOfMonth(1);
     LocalDate end =
         (endDate != null)
             ? endDate
-            : LocalDate.now().with(java.time.temporal.TemporalAdjusters.lastDayOfMonth());
+            : today.with(java.time.temporal.TemporalAdjusters.lastDayOfMonth());
 
     if (start.isAfter(end)) {
       throw new ResponseStatusException(

--- a/services/reservation-service/src/main/resources/application.yaml
+++ b/services/reservation-service/src/main/resources/application.yaml
@@ -41,6 +41,7 @@ management:
         include: health,info
 
 kwatera:
+  business-zone: ${KWATERA_BUSINESS_ZONE:Europe/Warsaw}
   mail:
     from: ${KWATERA_MAIL_FROM:no-reply@kwatera.local}
     test-recipient: ${KWATERA_MAIL_TEST_RECIPIENT:guest@kwatera.local}

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceDashboardMetricsTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceDashboardMetricsTest.java
@@ -30,6 +30,7 @@ class ReservationServiceDashboardMetricsTest {
   @Mock private ReservationRepository reservationRepository;
   @Mock private RestTemplate restTemplate;
   @Mock private NbpExchangeRateClient nbpExchangeRateClient;
+  @Mock private BusinessDateProvider businessDateProvider;
 
   @InjectMocks private ReservationService reservationService;
 
@@ -40,6 +41,7 @@ class ReservationServiceDashboardMetricsTest {
   void setUp() {
     ownerId = UUID.randomUUID();
     unitId = UUID.randomUUID();
+    when(businessDateProvider.today()).thenReturn(LocalDate.of(2026, 5, 15));
   }
 
   @Test

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -41,7 +41,24 @@ class ReservationServiceTest {
       RestTemplate restTemplate,
       NbpExchangeRateClient nbpExchangeRateClient) {
     return new ReservationService(
-        repository, restTemplate, nbpExchangeRateClient, mock(EmailNotificationService.class));
+        repository,
+        restTemplate,
+        nbpExchangeRateClient,
+        mock(EmailNotificationService.class),
+        new BusinessDateProvider("Europe/Warsaw"));
+  }
+
+  private ReservationService reservationService(
+      ReservationRepository repository,
+      RestTemplate restTemplate,
+      NbpExchangeRateClient nbpExchangeRateClient,
+      BusinessDateProvider businessDateProvider) {
+    return new ReservationService(
+        repository,
+        restTemplate,
+        nbpExchangeRateClient,
+        mock(EmailNotificationService.class),
+        businessDateProvider);
   }
 
   @Test
@@ -876,7 +893,8 @@ class ReservationServiceTest {
             repository,
             mock(RestTemplate.class),
             mock(NbpExchangeRateClient.class),
-            emailNotificationService);
+            emailNotificationService,
+            new BusinessDateProvider("Europe/Warsaw"));
 
     UUID reservationId = UUID.randomUUID();
 
@@ -1608,5 +1626,66 @@ class ReservationServiceTest {
 
     assertEquals(0L, metrics.getOccupiedDays());
     assertEquals(0.0, metrics.getOccupancyRate());
+  }
+
+  @Test
+  void shouldRejectDateThatIsYesterdayInBusinessZoneEvenWhenUtcStillPreviousDay() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    BusinessDateProvider businessDateProvider = mock(BusinessDateProvider.class);
+    ReservationService service =
+        reservationService(
+            repository,
+            mock(RestTemplate.class),
+            mock(NbpExchangeRateClient.class),
+            businessDateProvider);
+
+    UUID unitId = UUID.randomUUID();
+
+    LocalDate businessTodayInWarsaw = LocalDate.of(2026, 6, 6);
+    LocalDate businessYesterdayInWarsaw = businessTodayInWarsaw.minusDays(1);
+    LocalDate checkoutDate = businessTodayInWarsaw.plusDays(1);
+
+    when(businessDateProvider.today()).thenReturn(businessTodayInWarsaw);
+
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> service.checkAvailability(unitId, businessYesterdayInWarsaw, checkoutDate));
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    assertEquals("Date is in the past", exception.getReason());
+
+    verify(repository, never()).findByUnitId(unitId);
+  }
+
+  @Test
+  void shouldUseBusinessMonthForDashboardMetricsWhenWarsawIsAlreadyNextMonthButUtcIsNot() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    BusinessDateProvider businessDateProvider = mock(BusinessDateProvider.class);
+    ReservationService service =
+        reservationService(
+            repository, restTemplate, mock(NbpExchangeRateClient.class), businessDateProvider);
+
+    UUID unitId = UUID.randomUUID();
+
+    LocalDate expectedBusinessMonthStart = LocalDate.of(2026, 6, 1);
+    LocalDate expectedBusinessMonthEnd = LocalDate.of(2026, 6, 30);
+
+    when(businessDateProvider.today()).thenReturn(expectedBusinessMonthStart);
+    when(restTemplate.getForObject(
+            eq("http://property-service/api/properties/units/ids"), eq(UUID[].class)))
+        .thenReturn(new UUID[] {unitId});
+    when(repository.countReservationsInDateRange(any(LocalDate.class), any(LocalDate.class)))
+        .thenReturn(0L);
+    when(repository.findActiveReservationsInDateRange(any(LocalDate.class), any(LocalDate.class)))
+        .thenReturn(List.of());
+
+    service.getDashboardReservationMetrics(null, null, null, true);
+
+    verify(repository)
+        .countReservationsInDateRange(expectedBusinessMonthStart, expectedBusinessMonthEnd);
+    verify(repository)
+        .findActiveReservationsInDateRange(expectedBusinessMonthStart, expectedBusinessMonthEnd);
   }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceValidationTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceValidationTest.java
@@ -21,7 +21,8 @@ class ReservationServiceValidationTest {
           mock(
               io.github.kwatera_project.kwatera.reservation_service.client.NbpExchangeRateClient
                   .class),
-          mock(EmailNotificationService.class));
+          mock(EmailNotificationService.class),
+          new BusinessDateProvider("Europe/Warsaw"));
 
   @Test
   void shouldThrow_whenDatesAreNull() {

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/Stage2ReservationFlowTest.java
@@ -56,7 +56,8 @@ class Stage2ReservationFlowTest {
             mock(
                 io.github.kwatera_project.kwatera.reservation_service.client.NbpExchangeRateClient
                     .class),
-            emailNotificationService);
+            emailNotificationService,
+            new BusinessDateProvider("Europe/Warsaw"));
     adminReservationService =
         new AdminReservationService(
             reservationRepository,


### PR DESCRIPTION
## Summary
Replace text labels in forms, tables, and details views from "Location" to "City".

## Linked issue
Closes #116 

## Scope of changes

- All user-facing references to "Location" in the property/unit context are changed to "City"


## Testing status
Describe how this was verified.

- [x] Tested locally
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable
- [x] Not applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
- [x] Ready for review