### PR TITLE
119 polish add occupancy and revenue charts on the dashboard

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -7,12 +7,13 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "date-fns": "^4.2.1",
-        "lucide-react": "^1.17.0",
         "heic2any": "^0.0.4",
+        "lucide-react": "^1.17.0",
         "react": "^19.2.4",
         "react-datepicker": "^9.1.0",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.26.2",
+        "recharts": "^3.8.1",
         "tailwindcss": "^4.2.2",
       },
       "devDependencies": {
@@ -22,6 +23,7 @@
         "@types/react-datepicker": "^7.0.0",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -31,6 +33,9 @@
         "vite": "^8.0.4",
       },
     },
+  },
+  "overrides": {
+    "react-is": "^19.0.0",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -70,6 +75,58 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -121,6 +178,8 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.124.0", "", {}, "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
+
     "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
@@ -155,6 +214,10 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.2", "@tailwindcss/oxide-darwin-arm64": "4.2.2", "@tailwindcss/oxide-darwin-x64": "4.2.2", "@tailwindcss/oxide-freebsd-x64": "4.2.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2", "@tailwindcss/oxide-linux-arm64-musl": "4.2.2", "@tailwindcss/oxide-linux-x64-gnu": "4.2.2", "@tailwindcss/oxide-linux-x64-musl": "4.2.2", "@tailwindcss/oxide-wasm32-wasi": "4.2.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2", "@tailwindcss/oxide-win32-x64-msvc": "4.2.2" } }, "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg=="],
@@ -187,6 +250,24 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -198,6 +279,8 @@
     "@types/react-datepicker": ["@types/react-datepicker@7.0.0", "", { "dependencies": { "react-datepicker": "*" } }, "sha512-4tWwOUq589tozyQPBVEqGNng5DaZkomx5IVNuur868yYdgjH6RaL373/HKiVt1IDoNNXYiTGspm1F7kjrarM8Q=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/type-utils": "8.58.2", "@typescript-eslint/utils": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw=="],
 
@@ -259,9 +342,33 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "date-fns": ["date-fns@4.2.1", "", {}, "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -270,6 +377,10 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.339", "", {}, "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
+
+    "es-toolkit": ["es-toolkit@1.47.0", "", {}, "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw=="],
+
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -294,6 +405,8 @@
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -331,9 +444,13 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -433,9 +550,21 @@
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
+    "react-is": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
+
+    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
+
     "react-router": ["react-router@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="],
 
     "react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
+
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -461,6 +590,8 @@
 
     "tapable": ["tapable@2.3.2", "", {}, "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
@@ -479,6 +610,10 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -496,6 +631,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react-datepicker": "^9.1.0",
         "react-dom": "^19.2.4",
         "react-router-dom": "^6.26.2",
+        "recharts": "^3.8.1",
         "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
@@ -633,6 +634,42 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -912,6 +949,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1179,6 +1228,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1208,7 +1320,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1235,6 +1347,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -1798,8 +1916,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/date-fns": {
       "version": "4.3.0",
@@ -1828,6 +2067,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1864,6 +2109,16 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.0.tgz",
+      "integrity": "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2073,6 +2328,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2261,6 +2522,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2286,6 +2557,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -2964,6 +3244,37 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "6.30.3",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
@@ -2995,6 +3306,58 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3144,6 +3507,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3278,6 +3647,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,13 +12,20 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "date-fns": "^4.2.1",
-    "lucide-react": "^1.17.0",
     "heic2any": "^0.0.4",
+    "lucide-react": "^1.17.0",
     "react": "^19.2.4",
     "react-datepicker": "^9.1.0",
     "react-dom": "^19.2.4",
     "react-router-dom": "^6.26.2",
+    "recharts": "^3.8.1",
     "tailwindcss": "^4.2.2"
+  },
+  "overrides": {
+    "react-is": "^19.0.0"
+  },
+  "resolutions": {
+    "react-is": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -27,6 +34,7 @@
     "@types/react-datepicker": "^7.0.0",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -29,16 +29,12 @@ import type { Unit } from "../types/property";
 import {
   Calendar,
   DollarSign,
-  TrendingUp,
   Percent,
   Activity,
   FileText,
   Shield,
   Loader2,
-  AlertCircle,
-  BarChart3,
-  Flame,
-  Award
+  AlertCircle
 } from "lucide-react";
 
 interface ReservationOverview {
@@ -727,8 +723,7 @@ export default function DashboardPage() {
             {/* Chart 1: Occupancy Trend (Area Chart) */}
             <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
               <div>
-                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
-                  <TrendingUp className="w-5 h-5 text-emerald-600" />
+                <h3 className="text-lg font-bold text-[#1A1A1A]">
                   Occupancy Trend
                 </h3>
                 <p className="text-xs text-[#7A7A7A]">
@@ -748,7 +743,7 @@ export default function DashboardPage() {
                       <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" vertical={false} />
                       <XAxis dataKey="label" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} dy={8} />
                       <YAxis stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} domain={[0, 100]} tickFormatter={(v) => `${v}%`} />
-                      <Tooltip content={<CustomOccupancyTooltip />} />
+                      <Tooltip content={<CustomOccupancyTooltip />} wrapperStyle={{ backgroundColor: 'transparent', border: 'none', outline: 'none' }} />
                       <Area type="monotone" dataKey="occupancy" stroke="#10B981" strokeWidth={2.5} fillOpacity={1} fill="url(#occupancyGrad)" />
                     </AreaChart>
                   </ResponsiveContainer>
@@ -763,8 +758,7 @@ export default function DashboardPage() {
             {/* Chart 2: AI Pricing Effectiveness (Line Chart) */}
             <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
               <div>
-                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
-                  <Flame className="w-5 h-5 text-indigo-600" />
+                <h3 className="text-lg font-bold text-[#1A1A1A]">
                   AI Pricing Effectiveness
                 </h3>
                 <p className="text-xs text-[#7A7A7A]">
@@ -778,7 +772,7 @@ export default function DashboardPage() {
                       <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" vertical={false} />
                       <XAxis dataKey="label" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} dy={8} />
                       <YAxis stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `zł${v}`} />
-                      <Tooltip content={<CustomPricingTooltip />} />
+                      <Tooltip content={<CustomPricingTooltip />} wrapperStyle={{ backgroundColor: 'transparent', border: 'none', outline: 'none' }} />
                       <Legend verticalAlign="top" height={36} iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 11, fontWeight: "bold" }} />
                       <Line type="monotone" dataKey="staticAdr" name="Static Base Price" stroke="#9CA3AF" strokeWidth={2} strokeDasharray="5 5" dot={false} activeDot={{ r: 4 }} />
                       <Line type="monotone" dataKey="aiAdr" name="AI-Predicted Price" stroke="#6366F1" strokeWidth={2.5} dot={{ r: 3, strokeWidth: 1 }} activeDot={{ r: 6 }} />
@@ -795,8 +789,7 @@ export default function DashboardPage() {
             {/* Chart 3: Net Profit & OCR Integration (Composed Chart) */}
             <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
               <div>
-                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
-                  <BarChart3 className="w-5 h-5 text-blue-600" />
+                <h3 className="text-lg font-bold text-[#1A1A1A]">
                   Net Profit & OCR billing
                 </h3>
                 <p className="text-xs text-[#7A7A7A]">
@@ -810,7 +803,7 @@ export default function DashboardPage() {
                       <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" vertical={false} />
                       <XAxis dataKey="label" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} dy={8} />
                       <YAxis stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `zł${v}`} />
-                      <Tooltip content={<CustomProfitTooltip />} />
+                      <Tooltip content={<CustomProfitTooltip />} wrapperStyle={{ backgroundColor: 'transparent', border: 'none', outline: 'none' }} />
                       <Legend verticalAlign="top" height={36} iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 11, fontWeight: "bold" }} />
                       <Bar dataKey="grossRevenue" name="Gross Revenue" fill="#3B82F6" radius={[4, 4, 0, 0]} barSize={20} />
                       <Bar dataKey="utilityCosts" name="Utility Expenses" fill="#EF4444" radius={[4, 4, 0, 0]} barSize={20} />
@@ -828,8 +821,7 @@ export default function DashboardPage() {
             {/* Chart 4: Unit Performance Ranking (Horizontal Bar Chart) */}
             <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
               <div>
-                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
-                  <Award className="w-5 h-5 text-amber-500" />
+                <h3 className="text-lg font-bold text-[#1A1A1A]">
                   Unit Profitability Ranking
                 </h3>
                 <p className="text-xs text-[#7A7A7A]">
@@ -847,7 +839,7 @@ export default function DashboardPage() {
                       <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" horizontal={false} />
                       <XAxis type="number" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `zł${v}`} />
                       <YAxis type="category" dataKey="name" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} width={80} />
-                      <Tooltip content={<CustomRankingTooltip />} />
+                      <Tooltip content={<CustomRankingTooltip />} wrapperStyle={{ backgroundColor: 'transparent', border: 'none', outline: 'none' }} />
                       <Bar dataKey="revenue" name="Total Revenue" fill="#42211D" radius={[0, 4, 4, 0]} barSize={14} />
                     </BarChart>
                   </ResponsiveContainer>
@@ -1041,7 +1033,7 @@ interface CustomTooltipProps {
 const CustomOccupancyTooltip = ({ active, payload, label }: CustomTooltipProps) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-white p-3.5 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-1">
+      <div className="bg-white p-3.5 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-1" style={{ backgroundColor: '#ffffff' }}>
         <p className="text-gray-400 font-bold uppercase tracking-wider text-[9px]">{label}</p>
         <p className="text-sm flex items-center gap-1.5 font-bold text-gray-900">
           <span className="w-2.5 h-2.5 rounded-full bg-emerald-500"></span>
@@ -1060,7 +1052,7 @@ const CustomPricingTooltip = ({ active, payload, label }: CustomTooltipProps) =>
     const diff = Number(aiVal) - Number(staticVal);
     const pct = Number(staticVal) > 0 ? (diff / Number(staticVal)) * 100 : 0;
     return (
-      <div className="bg-white p-4 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-2">
+      <div className="bg-white p-4 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-2" style={{ backgroundColor: '#ffffff' }}>
         <p className="text-gray-400 font-bold uppercase tracking-wider text-[9px]">{label}</p>
         <div className="space-y-1.5">
           <p className="flex items-center justify-between gap-4 font-semibold text-gray-600">
@@ -1094,7 +1086,7 @@ const CustomProfitTooltip = ({ active, payload, label }: CustomTooltipProps) => 
     const utilities = payload.find(p => p.dataKey === 'utilityCosts')?.value ?? 0;
     const net = Number(gross) - Number(utilities);
     return (
-      <div className="bg-white p-4 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-2">
+      <div className="bg-white p-4 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-2" style={{ backgroundColor: '#ffffff' }}>
         <p className="text-gray-400 font-bold uppercase tracking-wider text-[9px]">{label}</p>
         <div className="space-y-1.5">
           <p className="flex items-center justify-between gap-4 font-semibold text-blue-600">
@@ -1129,7 +1121,7 @@ const CustomRankingTooltip = ({ active, payload }: CustomTooltipProps) => {
     const uName = itemPayload.name || "Unknown Unit";
     const bookings = itemPayload.bookings || 0;
     return (
-      <div className="bg-white p-3.5 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-1.5">
+      <div className="bg-white p-3.5 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-1.5" style={{ backgroundColor: '#ffffff' }}>
         <p className="text-gray-900 font-extrabold">{uName}</p>
         <p className="text-sm font-bold text-gray-700 flex justify-between gap-4">
           <span>Total Revenue:</span>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -125,15 +125,28 @@ export default function DashboardPage() {
   const unpaidSettlementsCount = billMetrics?.unpaidSettlementsCount ?? 0;
 
 
-  const fetchAllReservations = async (): Promise<ReservationOverview[]> => {
-    const token = localStorage.getItem("token");
-    const res = await fetch(`${GATEWAY_BASE_URL}/api/v1/admin/reservations`, {
-      headers: {
-        Authorization: `Bearer ${token}`
+  const fetchAllReservations = async (isAdmin: boolean): Promise<ReservationOverview[]> => {
+    try {
+      const token = localStorage.getItem("token");
+      if (!token) return [];
+      const res = await fetch(`${GATEWAY_BASE_URL}/api/v1/admin/reservations`, {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      });
+      if (!res.ok) {
+        if (isAdmin) {
+          console.error(`Admin failed to fetch reservations: ${res.status}`);
+        } else {
+          console.warn(`Owner/non-admin reservation loading bypassed or failed with status ${res.status}. Returning empty list.`);
+        }
+        return [];
       }
-    });
-    if (!res.ok) throw new Error("Failed to fetch reservations list");
-    return res.json();
+      return await res.json();
+    } catch (err) {
+      console.error("Error in fetchAllReservations:", err);
+      return [];
+    }
   };
 
   const fetchTotalUnits = async (isAdminRole: boolean): Promise<Unit[]> => {
@@ -192,7 +205,7 @@ export default function DashboardPage() {
       const [resData, billData, rawReservations, unitsList] = await Promise.all([
         getDashboardReservationMetrics(startStr, endStr),
         getDashboardBillingMetrics(startStr, endStr),
-        fetchAllReservations(),
+        fetchAllReservations(isAdminRole),
         fetchTotalUnits(isAdminRole)
       ]);
 
@@ -755,14 +768,14 @@ export default function DashboardPage() {
               </div>
             </div>
 
-            {/* Chart 2: AI Pricing Effectiveness (Line Chart) */}
+            {/* Chart 2: Base vs. Sold Price Analysis (Line Chart) */}
             <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
               <div>
                 <h3 className="text-lg font-bold text-[#1A1A1A]">
-                  AI Pricing Effectiveness
+                  Base vs. Sold Price Analysis
                 </h3>
                 <p className="text-xs text-[#7A7A7A]">
-                  Comparison between the Unit Base Price and actual AI-dynamic price sold.
+                  Comparison between the base property price and the actual price sold (ADR).
                 </p>
               </div>
               <div className="h-80 w-full">
@@ -775,7 +788,7 @@ export default function DashboardPage() {
                       <Tooltip content={<CustomPricingTooltip />} wrapperStyle={{ backgroundColor: 'transparent', border: 'none', outline: 'none' }} />
                       <Legend verticalAlign="top" height={36} iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 11, fontWeight: "bold" }} />
                       <Line type="monotone" dataKey="staticAdr" name="Static Base Price" stroke="#9CA3AF" strokeWidth={2} strokeDasharray="5 5" dot={false} activeDot={{ r: 4 }} />
-                      <Line type="monotone" dataKey="aiAdr" name="AI-Predicted Price" stroke="#6366F1" strokeWidth={2.5} dot={{ r: 3, strokeWidth: 1 }} activeDot={{ r: 6 }} />
+                      <Line type="monotone" dataKey="aiAdr" name="Actual Price (ADR)" stroke="#6366F1" strokeWidth={2.5} dot={{ r: 3, strokeWidth: 1 }} activeDot={{ r: 6 }} />
                     </LineChart>
                   </ResponsiveContainer>
                 ) : (
@@ -786,14 +799,14 @@ export default function DashboardPage() {
               </div>
             </div>
 
-            {/* Chart 3: Net Profit & OCR Integration (Composed Chart) */}
+            {/* Chart 3: Net Profit & Utility Expenses (Composed Chart) */}
             <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
               <div>
                 <h3 className="text-lg font-bold text-[#1A1A1A]">
-                  Net Profit & OCR billing
+                  Net Profit & Utility Expenses
                 </h3>
                 <p className="text-xs text-[#7A7A7A]">
-                  Gross revenue mapped against OCR-extracted media and utility expenses.
+                  Gross revenue mapped against media and utility expenses.
                 </p>
               </div>
               <div className="h-80 w-full">
@@ -1065,12 +1078,12 @@ const CustomPricingTooltip = ({ active, payload, label }: CustomTooltipProps) =>
           <p className="flex items-center justify-between gap-4 font-semibold text-indigo-600">
             <span className="flex items-center gap-1.5">
               <span className="w-2.5 h-2.5 rounded-full bg-indigo-500"></span>
-              AI Sold Price (ADR):
+              Actual Sold Price (ADR):
             </span>
             <span>zł{Number(aiVal).toLocaleString("pl-PL", { minimumFractionDigits: 2 })}</span>
           </p>
           <div className="border-t border-gray-100 pt-1.5 mt-1.5 flex items-center justify-between gap-4 font-bold text-emerald-600">
-            <span>AI Premium Margin:</span>
+            <span>Pricing Margin:</span>
             <span>+zł{diff.toLocaleString("pl-PL", { minimumFractionDigits: 2 })} ({pct.toFixed(1)}%)</span>
           </div>
         </div>
@@ -1099,7 +1112,7 @@ const CustomProfitTooltip = ({ active, payload, label }: CustomTooltipProps) => 
           <p className="flex items-center justify-between gap-4 font-semibold text-red-600">
             <span className="flex items-center gap-1.5">
               <span className="w-2.5 h-2.5 rounded-full bg-red-500"></span>
-              Utility Costs (OCR):
+              Utility Costs:
             </span>
             <span>zł{Number(utilities).toLocaleString("pl-PL")}</span>
           </p>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,8 +1,56 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { format } from "date-fns";
 import { getDashboardReservationMetrics, getDashboardBillingMetrics } from "../api/adminApi";
+import { getMyProperties } from "../api/ownerPropertyApi";
+import { getPropertyUnits } from "../api/ownerUnitApi";
+import { getProperties, getUnits } from "../api/propertyApi";
+import { getSettlementDetails } from "../api/settlementApi";
+import { getUserRoles } from "../utils/jwtUtils";
+import { GATEWAY_BASE_URL } from "../api/apiConfig";
 import SharedDatePicker from "../components/SharedDatePicker";
 import DatePicker from "react-datepicker";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  ComposedChart,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend
+} from "recharts";
+import type { TooltipPayloadEntry } from "recharts";
+import type { Unit } from "../types/property";
+import {
+  Calendar,
+  DollarSign,
+  TrendingUp,
+  Percent,
+  Activity,
+  FileText,
+  Shield,
+  Loader2,
+  AlertCircle,
+  BarChart3,
+  Flame,
+  Award
+} from "lucide-react";
+
+interface ReservationOverview {
+  id: string;
+  guestName: string;
+  unitName: string;
+  startDate: string;
+  endDate: string;
+  status: string;
+  pricePerNightSnapshot?: number;
+  totalPrice?: number;
+}
 
 interface ReservationMetrics {
   totalReservations: number;
@@ -17,15 +65,30 @@ interface BillingMetrics {
   unpaidSettlementsCount: number;
 }
 
+interface ChartDataPoint {
+  label: string;
+  occupancy: number;
+  staticAdr: number;
+  aiAdr: number;
+  grossRevenue: number;
+  utilityCosts: number;
+  netProfit: number;
+}
+
+interface RankingDataPoint {
+  name: string;
+  revenue: number;
+  bookings: number;
+}
+
 export default function DashboardPage() {
   const getInitialDates = () => {
     const now = new Date();
-    const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
-    const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-
+    const start = new Date();
+    start.setDate(now.getDate() - 30);
     return {
-      start: firstDay,
-      end: lastDay,
+      start,
+      end: now,
     };
   };
 
@@ -34,6 +97,7 @@ export default function DashboardPage() {
   const [endDate, setEndDate] = useState<Date | null>(initialDates.end);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [userRole, setUserRole] = useState<"ADMIN" | "OWNER" | "GUEST" | "">("");
 
   const hasFetched = useRef(false);
   const dateToRef = useRef<DatePicker | null>(null);
@@ -51,6 +115,66 @@ export default function DashboardPage() {
     unpaidSettlementsCount: 0,
   });
 
+  const [chartData, setChartData] = useState<ChartDataPoint[]>([]);
+  const [rankingData, setRankingData] = useState<RankingDataPoint[]>([]);
+  const [totalUnitsCount, setTotalUnitsCount] = useState<number>(0);
+
+  const totalReservations = resMetrics?.totalReservations ?? 0;
+  const occupancyRate = resMetrics?.occupancyRate ?? 0;
+  const occupiedDays = resMetrics?.occupiedDays ?? 0;
+
+  const revenueFromSettlements = billMetrics?.revenueFromSettlements ?? 0;
+  const unpaidBalance = billMetrics?.unpaidBalance ?? 0;
+  const paidSettlementsCount = billMetrics?.paidSettlementsCount ?? 0;
+  const unpaidSettlementsCount = billMetrics?.unpaidSettlementsCount ?? 0;
+
+
+  const fetchAllReservations = async (): Promise<ReservationOverview[]> => {
+    const token = localStorage.getItem("token");
+    const res = await fetch(`${GATEWAY_BASE_URL}/api/v1/admin/reservations`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    if (!res.ok) throw new Error("Failed to fetch reservations list");
+    return res.json();
+  };
+
+  const fetchTotalUnits = async (isAdminRole: boolean): Promise<Unit[]> => {
+    try {
+      if (isAdminRole) {
+        const properties = await getProperties();
+        if (!properties || !Array.isArray(properties)) return [];
+        const unitsPromises = properties.map(async (p) => {
+          try {
+            const resUnits = await getUnits(p.id);
+            return Array.isArray(resUnits) ? (resUnits as Unit[]) : [];
+          } catch {
+            return [];
+          }
+        });
+        const unitsLists = await Promise.all(unitsPromises);
+        return unitsLists.flat();
+      } else {
+        const properties = await getMyProperties();
+        if (!properties || !Array.isArray(properties)) return [];
+        const unitsPromises = properties.map(async (p) => {
+          try {
+            const resUnits = await getPropertyUnits(p.id);
+            return Array.isArray(resUnits) ? (resUnits as Unit[]) : [];
+          } catch {
+            return [];
+          }
+        });
+        const unitsLists = await Promise.all(unitsPromises);
+        return unitsLists.flat();
+      }
+    } catch (err) {
+      console.error("Error fetching units count:", err);
+      return [];
+    }
+  };
+
   const fetchData = useCallback(async (start: Date | null, end: Date | null) => {
     if (!start || !end) return;
     setLoading(true);
@@ -58,12 +182,267 @@ export default function DashboardPage() {
     try {
       const startStr = format(start, "yyyy-MM-dd");
       const endStr = format(end, "yyyy-MM-dd");
-      const [resData, billData] = await Promise.all([
+
+      const token = localStorage.getItem("token");
+      const roles = getUserRoles(token);
+      const isAdminRole = roles.includes("ROLE_ADMIN");
+      const isOwnerRole = roles.includes("ROLE_OWNER");
+      
+      let detectedRole: "ADMIN" | "OWNER" | "GUEST" = "GUEST";
+      if (isAdminRole) detectedRole = "ADMIN";
+      else if (isOwnerRole) detectedRole = "OWNER";
+      setUserRole(detectedRole);
+
+      const [resData, billData, rawReservations, unitsList] = await Promise.all([
         getDashboardReservationMetrics(startStr, endStr),
         getDashboardBillingMetrics(startStr, endStr),
+        fetchAllReservations(),
+        fetchTotalUnits(isAdminRole)
       ]);
+
       setResMetrics(resData);
       setBillMetrics(billData);
+
+      const unitsCount = Array.isArray(unitsList) ? unitsList.filter(Boolean).length : 0;
+      setTotalUnitsCount(unitsCount);
+
+      const unitsMap = new Map<string, Unit>(
+        Array.isArray(unitsList) ? unitsList.filter(u => u && u.name).map(u => [u.name, u]) : []
+      );
+
+      const avgBasePrice = unitsCount > 0
+        ? unitsList.filter(Boolean).reduce((sum, u) => sum + (u.pricePerNight || 0), 0) / unitsCount
+        : 180;
+
+      const rangeStartStr = format(start, "yyyy-MM-dd");
+      const rangeEndStr = format(end, "yyyy-MM-dd");
+      
+      const activeOverlapping = Array.isArray(rawReservations)
+        ? rawReservations.filter((res) => {
+            return (
+              res &&
+              res.status !== "CANCELLED" &&
+              res.startDate &&
+              res.endDate &&
+              res.startDate <= rangeEndStr &&
+              res.endDate >= rangeStartStr
+            );
+          })
+        : [];
+
+      const settlementsPromises = activeOverlapping.map(async (res) => {
+        try {
+          const settlement = await getSettlementDetails(res.id);
+          return { reservationId: res.id, settlement };
+        } catch {
+          return { reservationId: res.id, settlement: null };
+        }
+      });
+      const settlementsResults = await Promise.all(settlementsPromises);
+      const settlementsMap = new Map(settlementsResults.map(s => [s.reservationId, s.settlement]));
+
+      const dateList: Date[] = [];
+      const curr = new Date(start);
+      curr.setHours(0, 0, 0, 0);
+      const endLimit = new Date(end);
+      endLimit.setHours(0, 0, 0, 0);
+
+      while (curr <= endLimit) {
+        dateList.push(new Date(curr));
+        curr.setDate(curr.getDate() + 1);
+      }
+
+      const dailyOccupancyMap = new Map<string, number>();
+      const dailyGrossRevenueMap = new Map<string, number>();
+      const dailyUtilityCostsMap = new Map<string, number>();
+
+      dateList.forEach(date => {
+        const dStr = format(date, "yyyy-MM-dd");
+        dailyOccupancyMap.set(dStr, 0);
+        dailyGrossRevenueMap.set(dStr, 0);
+        dailyUtilityCostsMap.set(dStr, 0);
+      });
+
+      dateList.forEach(date => {
+        const dStr = format(date, "yyyy-MM-dd");
+        const occupiedUnits = new Set<string>();
+        
+        activeOverlapping.forEach((res) => {
+          if (res.startDate <= dStr && dStr < res.endDate) {
+            occupiedUnits.add(res.unitName || res.id);
+          }
+        });
+
+        const rate = unitsCount > 0 ? (occupiedUnits.size / unitsCount) * 100 : 0;
+        dailyOccupancyMap.set(dStr, rate);
+      });
+
+      activeOverlapping.forEach((res) => {
+        const settlement = settlementsMap.get(res.id);
+        if (settlement) {
+          const revenue = settlement.accommodationAmount || settlement.totalAmount || 0;
+          const utilities = settlement.utilitiesAmount || 0;
+
+          const rawDate = settlement.paidAt || settlement.issuedAt || res.startDate;
+          if (rawDate) {
+            try {
+              const dateStr = format(new Date(rawDate), "yyyy-MM-dd");
+              const revEntry = dailyGrossRevenueMap.get(dateStr);
+              if (revEntry !== undefined) dailyGrossRevenueMap.set(dateStr, revEntry + revenue);
+              
+              const utilEntry = dailyUtilityCostsMap.get(dateStr);
+              if (utilEntry !== undefined) dailyUtilityCostsMap.set(dateStr, utilEntry + utilities);
+            } catch (e) {
+              console.error("Failed to parse settlement date", rawDate, e);
+            }
+          }
+        } else {
+          const dateStr = res.startDate;
+          if (dateStr) {
+            const revEntry = dailyGrossRevenueMap.get(dateStr);
+            if (revEntry !== undefined) {
+              dailyGrossRevenueMap.set(dateStr, revEntry + (res.totalPrice || 0));
+            }
+          }
+        }
+      });
+
+      const dailyPoints = dateList.map(date => {
+        const dStr = format(date, "yyyy-MM-dd");
+        const occupancy = dailyOccupancyMap.get(dStr) || 0;
+        
+        let occupiedCount = 0;
+        let sumStatic = 0;
+        let sumActual = 0;
+
+        activeOverlapping.forEach(res => {
+          if (res.startDate <= dStr && dStr < res.endDate) {
+            occupiedCount++;
+            const uInfo = unitsMap.get(res.unitName);
+            sumStatic += uInfo ? (uInfo.pricePerNight || 0) : (res.pricePerNightSnapshot || 0);
+            sumActual += res.pricePerNightSnapshot || 0;
+          }
+        });
+
+        const staticAdr = occupiedCount > 0 ? (sumStatic / occupiedCount) : avgBasePrice;
+        const aiAdr = occupiedCount > 0 ? (sumActual / occupiedCount) : avgBasePrice;
+
+        const grossRevenue = dailyGrossRevenueMap.get(dStr) || 0;
+        const utilityCosts = dailyUtilityCostsMap.get(dStr) || 0;
+
+        return {
+          date,
+          dateStr: dStr,
+          label: format(date, "MMM dd"),
+          occupancy: Math.round(occupancy * 10) / 10,
+          staticAdr: Math.round(staticAdr * 100) / 100,
+          aiAdr: Math.round(aiAdr * 100) / 100,
+          grossRevenue: Math.round(grossRevenue * 100) / 100,
+          utilityCosts: Math.round(utilityCosts * 100) / 100,
+          netProfit: Math.round((grossRevenue - utilityCosts) * 100) / 100
+        };
+      });
+
+      const diffDays = dailyPoints.length;
+      let grouped: ChartDataPoint[] = [];
+
+      if (diffDays <= 31) {
+        grouped = dailyPoints.map(p => ({
+          label: p.label,
+          occupancy: p.occupancy,
+          staticAdr: p.staticAdr,
+          aiAdr: p.aiAdr,
+          grossRevenue: p.grossRevenue,
+          utilityCosts: p.utilityCosts,
+          netProfit: p.netProfit
+        }));
+      } else if (diffDays <= 120) {
+        const weeks: Record<string, typeof dailyPoints> = {};
+        dailyPoints.forEach(p => {
+          const dayOfWeek = p.date.getDay();
+          const diff = p.date.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
+          const weekStart = new Date(p.date);
+          weekStart.setDate(diff);
+          const weekKey = format(weekStart, "yyyy-MM-dd");
+          if (!weeks[weekKey]) {
+            weeks[weekKey] = [];
+          }
+          weeks[weekKey].push(p);
+        });
+
+        grouped = Object.keys(weeks).sort().map(weekKey => {
+          const points = weeks[weekKey];
+          const avgOccupancy = points.reduce((sum, p) => sum + p.occupancy, 0) / points.length;
+          const avgStaticAdr = points.reduce((sum, p) => sum + p.staticAdr, 0) / points.length;
+          const avgAiAdr = points.reduce((sum, p) => sum + p.aiAdr, 0) / points.length;
+          const sumGross = points.reduce((sum, p) => sum + p.grossRevenue, 0);
+          const sumUtil = points.reduce((sum, p) => sum + p.utilityCosts, 0);
+          const weekStart = new Date(weekKey);
+          return {
+            label: `Wk of ${format(weekStart, "MMM dd")}`,
+            occupancy: Math.round(avgOccupancy * 10) / 10,
+            staticAdr: Math.round(avgStaticAdr * 100) / 100,
+            aiAdr: Math.round(avgAiAdr * 100) / 100,
+            grossRevenue: Math.round(sumGross * 100) / 100,
+            utilityCosts: Math.round(sumUtil * 100) / 100,
+            netProfit: Math.round((sumGross - sumUtil) * 100) / 100
+          };
+        });
+      } else {
+        const months: Record<string, typeof dailyPoints> = {};
+        dailyPoints.forEach(p => {
+          const monthKey = format(p.date, "yyyy-MM");
+          if (!months[monthKey]) {
+            months[monthKey] = [];
+          }
+          months[monthKey].push(p);
+        });
+
+        grouped = Object.keys(months).sort().map(monthKey => {
+          const points = months[monthKey];
+          const avgOccupancy = points.reduce((sum, p) => sum + p.occupancy, 0) / points.length;
+          const avgStaticAdr = points.reduce((sum, p) => sum + p.staticAdr, 0) / points.length;
+          const avgAiAdr = points.reduce((sum, p) => sum + p.aiAdr, 0) / points.length;
+          const sumGross = points.reduce((sum, p) => sum + p.grossRevenue, 0);
+          const sumUtil = points.reduce((sum, p) => sum + p.utilityCosts, 0);
+          const parsedDate = new Date(monthKey + "-02");
+          return {
+            label: format(parsedDate, "MMM yyyy"),
+            occupancy: Math.round(avgOccupancy * 10) / 10,
+            staticAdr: Math.round(avgStaticAdr * 100) / 100,
+            aiAdr: Math.round(avgAiAdr * 100) / 100,
+            grossRevenue: Math.round(sumGross * 100) / 100,
+            utilityCosts: Math.round(sumUtil * 100) / 100,
+            netProfit: Math.round((sumGross - sumUtil) * 100) / 100
+          };
+        });
+      }
+
+      setChartData(grouped);
+
+      const rankingMap = new Map<string, { revenue: number; bookings: number }>();
+      activeOverlapping.forEach(res => {
+        const uName = res.unitName || "Unknown Unit";
+        const settlement = settlementsMap.get(res.id);
+        const rev = settlement ? (settlement.totalAmount || 0) : (res.totalPrice || 0);
+        
+        const entry = rankingMap.get(uName) || { revenue: 0, bookings: 0 };
+        rankingMap.set(uName, {
+          revenue: entry.revenue + rev,
+          bookings: entry.bookings + 1
+        });
+      });
+
+      const rankingDataPoints = Array.from(rankingMap.entries())
+        .map(([name, val]) => ({
+          name,
+          revenue: Math.round(val.revenue * 100) / 100,
+          bookings: val.bookings
+        }))
+        .sort((a, b) => b.revenue - a.revenue)
+        .slice(0, 8);
+
+      setRankingData(rankingDataPoints);
     } catch (err: unknown) {
       console.error(err);
       const errMsg = err instanceof Error ? err.message : "Failed to retrieve dashboard metrics.";
@@ -95,22 +474,24 @@ export default function DashboardPage() {
     const endStr = format(endDate, "yyyy-MM-dd");
 
     const csvRows = [
-      ["KWATERA PROPERTY MANAGEMENT - ADMIN/OWNER DASHBOARD REPORT"],
+      ["KWATERA PROPERTY MANAGEMENT - SYSTEM REPORT"],
       [`Generated on: ${new Date().toLocaleString()}`],
       [`Period: ${startStr} to ${endStr}`],
+      [`Role Scoping: ${userRole}`],
       [],
       ["RESERVATION METRICS"],
       ["Metric", "Value"],
-      ["Total Reservations", String(resMetrics.totalReservations)],
-      ["Occupancy Rate", `${resMetrics.occupancyRate}%`],
-      ["Occupied Days", String(resMetrics.occupiedDays)],
+      ["Total Reservations", String(totalReservations)],
+      ["Occupancy Rate", `${occupancyRate}%`],
+      ["Occupied Days", String(occupiedDays)],
+      ["Total Scoped Properties/Units", String(totalUnitsCount)],
       [],
       ["BILLING METRICS"],
       ["Metric", "Value (PLN)"],
-      ["Total Revenue (Paid Settlements)", String(billMetrics.revenueFromSettlements)],
-      ["Unpaid Balance (Receivables)", String(billMetrics.unpaidBalance)],
-      ["Paid Settlements Count", String(billMetrics.paidSettlementsCount)],
-      ["Unpaid Settlements Count", String(billMetrics.unpaidSettlementsCount)]
+      ["Total Collected Revenue", String(revenueFromSettlements)],
+      ["Unpaid Receivables Balance", String(unpaidBalance)],
+      ["Paid Invoices Count", String(paidSettlementsCount)],
+      ["Unpaid Invoices Count", String(unpaidSettlementsCount)]
     ];
 
     const csvContent = csvRows
@@ -121,395 +502,645 @@ export default function DashboardPage() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.setAttribute("href", url);
-    link.setAttribute("download", `kwatera-dashboard-report-${startStr}-to-${endStr}.csv`);
-    link.style.visibility = 'hidden';
+    link.setAttribute("download", `kwatera-${userRole.toLowerCase()}-report-${startStr}-to-${endStr}.csv`);
+    link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
   };
 
-  const totalSettlements = billMetrics.paidSettlementsCount + billMetrics.unpaidSettlementsCount;
-  const paidPct = totalSettlements > 0 ? (billMetrics.paidSettlementsCount / totalSettlements) * 100 : 0;
+  const totalSettlements = paidSettlementsCount + unpaidSettlementsCount;
+  const paidPct = totalSettlements > 0 ? (paidSettlementsCount / totalSettlements) * 100 : 0;
+
+
 
   return (
-    <div className="p-8 max-w-7xl mx-auto min-h-screen text-[#1A1A1A]">
-      <div className="max-w-7xl mx-auto space-y-8">
-        
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 border-b border-[#DACDCA] pb-6">
-          <div>
-            <h1 className="text-3xl font-bold text-[#1A1A1A]">Dashboard</h1>
-            <p className="text-sm text-[#7A7A7A] mt-1">
-              Monitor reservation occupancy, settlements, and revenue summaries.
-            </p>
+    <div className="p-8 max-w-7xl mx-auto min-h-screen text-[#1A1A1A] space-y-8">
+      {/* Header section */}
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 border-b border-[#DACDCA] pb-6">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-extrabold text-[#1A1A1A] tracking-tight">Dashboard</h1>
+            {userRole && (
+              <span className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-bold border uppercase tracking-wider ${
+                userRole === "ADMIN" 
+                  ? "bg-red-50 text-red-800 border-red-200" 
+                  : "bg-indigo-50 text-indigo-800 border-indigo-200"
+              }`}>
+                <Shield className="w-3.5 h-3.5" />
+                {userRole === "ADMIN" ? "Global Administrator" : "Property Owner"}
+              </span>
+            )}
           </div>
-
-          <form onSubmit={handleFilterSubmit} className="flex flex-wrap items-center gap-3 bg-white p-3 rounded-xl shadow-sm border border-[#DACDCA]">
-            <div className="flex items-center gap-2">
-              <label className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">From</label>
-              <div className="flex items-center bg-[#F7F7F7] border border-[#DACDCA] rounded-lg px-3 py-1.5 shadow-sm focus-within:ring-1 focus-within:ring-[#42211D] gap-2">
-                <SharedDatePicker
-                  selected={startDate}
-                  onChange={(date) => {
-                    setStartDate(date);
-                    if (date) {
-                      setTimeout(() => {
-                        dateToRef.current?.setOpen(true);
-                      }, 100);
-                    }
-                  }}
-                  selectsStart
-                  startDate={startDate}
-                  endDate={endDate}
-                  placeholderText="Start"
-                  className="bg-transparent text-sm font-bold text-[#1A1A1A] outline-none cursor-pointer w-24 text-center"
-                />
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <label className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">To</label>
-              <div className="flex items-center bg-[#F7F7F7] border border-[#DACDCA] rounded-lg px-3 py-1.5 shadow-sm focus-within:ring-1 focus-within:ring-[#42211D] gap-2">
-                <SharedDatePicker
-                  datepickerRef={dateToRef}
-                  selected={endDate}
-                  onChange={(date) => setEndDate(date)}
-                  selectsEnd
-                  startDate={startDate}
-                  endDate={endDate}
-                  minDate={startDate}
-                  placeholderText="End"
-                  className="bg-transparent text-sm font-bold text-[#1A1A1A] outline-none cursor-pointer w-24 text-center"
-                />
-              </div>
-            </div>
-            <button
-              type="submit"
-              className="px-6 py-2 bg-[#42211D] text-white font-bold hover:bg-[#2a1412] text-sm rounded-lg transition-colors border border-[#DACDCA] shadow-sm cursor-pointer"
-            >
-              Filter
-            </button>
-            <button
-              type="button"
-              onClick={handleDownloadReport}
-              className="px-4 py-2 text-sm font-bold text-[#42211D] bg-[#F7F7F7] border border-[#DACDCA] hover:bg-gray-100 rounded-lg transition-colors shadow-sm cursor-pointer flex items-center gap-2"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/>
-              </svg>
-              Export CSV
-            </button>
-          </form>
+          <p className="text-sm text-[#7A7A7A]">
+            {userRole === "ADMIN" 
+              ? "Global performance metrics, system-wide occupancy, and cashflow volume."
+              : "Scoped owner stats, property occupancy trends, and unit revenue collection."}
+          </p>
         </div>
 
-        {error && (
-          <div className="flex items-center gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded-r-xl text-red-700 animate-fade-in shadow-sm">
-            <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd"/>
-            </svg>
-            <span className="text-sm font-medium">{error}</span>
+        <form onSubmit={handleFilterSubmit} className="flex flex-wrap items-center gap-3 bg-white p-3 rounded-xl shadow-sm border border-[#DACDCA]">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">From</span>
+            <div className="flex items-center bg-[#F7F7F7] border border-[#DACDCA] rounded-lg px-3 py-1.5 shadow-sm focus-within:ring-1 focus-within:ring-[#42211D]">
+              <SharedDatePicker
+                selected={startDate}
+                onChange={(date) => {
+                  setStartDate(date);
+                  if (date) {
+                    setTimeout(() => {
+                      dateToRef.current?.setOpen(true);
+                    }, 100);
+                  }
+                }}
+                selectsStart
+                startDate={startDate}
+                endDate={endDate}
+                placeholderText="Start"
+                className="bg-transparent text-sm font-bold text-[#1A1A1A] outline-none cursor-pointer w-24 text-center"
+              />
+            </div>
           </div>
-        )}
-
-        {loading ? (
-          <>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              {[...Array(4)].map((_, i) => (
-                <div key={i} className="bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm animate-pulse space-y-4">
-                  <div className="h-4 w-1/3 bg-[#F7F7F7] rounded"></div>
-                  <div className="h-8 w-2/3 bg-[#F7F7F7] rounded"></div>
-                  <div className="h-3 w-1/2 bg-[#F7F7F7] rounded"></div>
-                </div>
-              ))}
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">To</span>
+            <div className="flex items-center bg-[#F7F7F7] border border-[#DACDCA] rounded-lg px-3 py-1.5 shadow-sm focus-within:ring-1 focus-within:ring-[#42211D]">
+              <SharedDatePicker
+                datepickerRef={dateToRef}
+                selected={endDate}
+                onChange={(date) => setEndDate(date)}
+                selectsEnd
+                startDate={startDate}
+                endDate={endDate}
+                minDate={startDate}
+                placeholderText="End"
+                className="bg-transparent text-sm font-bold text-[#1A1A1A] outline-none cursor-pointer w-24 text-center"
+              />
             </div>
+          </div>
+          <button
+            type="submit"
+            className="px-5 py-2 bg-[#42211D] text-white font-bold hover:bg-[#2a1412] text-sm rounded-lg transition-colors border border-[#DACDCA] shadow-sm cursor-pointer"
+          >
+            Filter
+          </button>
+          <button
+            type="button"
+            onClick={handleDownloadReport}
+            className="px-4 py-2 text-sm font-bold text-[#42211D] bg-[#F7F7F7] border border-[#DACDCA] hover:bg-gray-100 rounded-lg transition-colors shadow-sm cursor-pointer flex items-center gap-2"
+          >
+            <FileText className="w-4 h-4" />
+            Export CSV
+          </button>
+        </form>
+      </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              {[...Array(2)].map((_, i) => (
-                <div key={i} className="bg-white p-8 rounded-xl border border-[#DACDCA] shadow-sm animate-pulse h-96"></div>
-              ))}
+      {error && (
+        <div className="flex items-center gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded-r-xl text-red-700 animate-fade-in shadow-sm">
+          <AlertCircle className="w-5 h-5 flex-shrink-0" />
+          <span className="text-sm font-medium">{error}</span>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="space-y-8">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm animate-pulse space-y-4">
+                <div className="h-4 w-1/3 bg-[#F7F7F7] rounded"></div>
+                <div className="h-8 w-2/3 bg-[#F7F7F7] rounded"></div>
+                <div className="h-3 w-1/2 bg-[#F7F7F7] rounded"></div>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div className="bg-white p-8 rounded-xl border border-[#DACDCA] shadow-sm animate-pulse h-96 flex items-center justify-center">
+              <Loader2 className="w-8 h-8 text-[#42211D] animate-spin" />
             </div>
-          </>
-        ) : (
-          <>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              
-              <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
-                <div className="absolute top-0 right-0 w-24 h-24 bg-[#42211D]/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
-                <div className="flex flex-col justify-between h-full space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
-                      Reservations
-                    </span>
-                    <span className="p-2 bg-[#42211D]/10 text-[#42211D] rounded-xl">
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-                      </svg>
-                    </span>
-                  </div>
-                  <div>
-                    <h2 className="text-3xl font-bold text-[#1A1A1A] tracking-tight">
-                      {resMetrics.totalReservations}
-                    </h2>
-                    <p className="text-xs text-[#7A7A7A] mt-2 font-medium">
-                      Active reservations within range
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
-                <div className="absolute top-0 right-0 w-24 h-24 bg-emerald-500/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
-                <div className="flex flex-col justify-between h-full space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
-                      Occupancy Rate
-                    </span>
-                    <span className="p-2 bg-emerald-100 text-emerald-700 rounded-xl">
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
-                      </svg>
-                    </span>
-                  </div>
-                  <div>
-                    <h2 className="text-3xl font-bold text-[#1A1A1A] tracking-tight flex items-baseline gap-1">
-                      {resMetrics.occupancyRate}%
-                    </h2>
-                    <div className="w-full bg-[#F7F7F7] border border-[#DACDCA] h-2 rounded-full mt-3 overflow-hidden">
-                      <div 
-                        className="bg-emerald-600 h-full rounded-full transition-all duration-1000" 
-                        style={{ width: `${resMetrics.occupancyRate}%` }}
-                      ></div>
-                    </div>
-                    <p className="text-[10px] text-[#7A7A7A] mt-2 font-medium">
-                      {resMetrics.occupiedDays} total occupied nights
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
-                <div className="absolute top-0 right-0 w-24 h-24 bg-blue-500/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
-                <div className="flex flex-col justify-between h-full space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
-                      Total Revenue
-                    </span>
-                    <span className="p-2 bg-blue-100 text-blue-700 rounded-xl">
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                      </svg>
-                    </span>
-                  </div>
-                  <div>
-                    <h2 className="text-3xl font-bold text-[#1A1A1A] tracking-tight">
-                      {billMetrics.revenueFromSettlements.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
-                    </h2>
-                    <p className="text-xs text-[#7A7A7A] mt-2 font-medium">
-                      Received settlements payments
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
-                <div className="absolute top-0 right-0 w-24 h-24 bg-amber-500/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
-                <div className="flex flex-col justify-between h-full space-y-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
-                      Unpaid Balance
-                    </span>
-                    <span className="p-2 bg-amber-100 text-amber-700 rounded-xl">
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-                      </svg>
-                    </span>
-                  </div>
-                  <div>
-                    <h2 className="text-3xl font-bold text-[#1A1A1A] tracking-tight">
-                      {billMetrics.unpaidBalance.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
-                    </h2>
-                    <p className="text-xs text-[#7A7A7A] mt-2 font-medium">
-                      Outstanding invoice receivables
-                    </p>
-                  </div>
-                </div>
-              </div>
-
+            <div className="bg-white p-8 rounded-xl border border-[#DACDCA] shadow-sm animate-pulse h-96 flex items-center justify-center">
+              <Loader2 className="w-8 h-8 text-[#42211D] animate-spin" />
             </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              
-              <div className="bg-white p-6 sm:p-8 rounded-xl border border-[#DACDCA] shadow-sm flex flex-col justify-between h-96">
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {/* 1. Statistic tiles (Must NOT delete) */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
+              <div className="absolute top-0 right-0 w-24 h-24 bg-[#42211D]/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
+              <div className="flex flex-col justify-between h-full space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
+                    Reservations
+                  </span>
+                  <span className="p-2 bg-[#42211D]/10 text-[#42211D] rounded-xl">
+                    <Calendar className="w-5 h-5" />
+                  </span>
+                </div>
                 <div>
-                  <h3 className="text-lg font-bold text-[#1A1A1A]">
-                    Settlements Payment Status
-                  </h3>
-                  <p className="text-xs text-[#7A7A7A] mt-1">
-                    Proportion of paid versus unpaid settlements within date range.
+                  <h2 className="text-3xl font-extrabold text-[#1A1A1A] tracking-tight">
+                    {totalReservations}
+                  </h2>
+                  <p className="text-xs text-[#7A7A7A] mt-2 font-medium">
+                    Active bookings in selected range
                   </p>
                 </div>
-
-                <div className="flex flex-col sm:flex-row items-center justify-center gap-8 my-auto">
-                  {totalSettlements > 0 ? (
-                    <>
-                      <div className="relative w-40 h-40">
-                        <svg className="w-full h-full transform -rotate-90" viewBox="0 0 36 36">
-                          <circle
-                            cx="18"
-                            cy="18"
-                            r="15.915"
-                            fill="none"
-                            stroke="#F7F7F7"
-                            strokeWidth="3.2"
-                          />
-                          <circle
-                            cx="18"
-                            cy="18"
-                            r="15.915"
-                            fill="none"
-                            stroke="#42211D"
-                            strokeWidth="3.2"
-                            strokeDasharray={`${paidPct} ${100 - paidPct}`}
-                            strokeDashoffset="0"
-                            className="transition-all duration-1000 ease-out"
-                          />
-                          <circle
-                            cx="18"
-                            cy="18"
-                            r="15.915"
-                            fill="none"
-                            stroke="#F59E0B"
-                            strokeWidth="3.2"
-                            strokeDasharray={`${(100 - paidPct)} ${paidPct}`}
-                            strokeDashoffset={`-${paidPct}`}
-                            className="transition-all duration-1000 ease-out"
-                          />
-                        </svg>
-                        <div className="absolute inset-0 flex flex-col items-center justify-center">
-                          <span className="text-2xl font-black text-[#1A1A1A]">{totalSettlements}</span>
-                          <span className="text-[10px] uppercase font-bold tracking-widest text-[#7A7A7A]">Total</span>
-                        </div>
-                      </div>
-
-                      <div className="flex flex-col gap-3">
-                        <div className="flex items-center gap-3">
-                          <span className="w-3.5 h-3.5 rounded-full bg-[#42211D] flex-shrink-0"></span>
-                          <div className="flex flex-col">
-                            <span className="text-sm font-semibold text-gray-700">Paid Invoices</span>
-                            <span className="text-xs font-medium text-[#7A7A7A]">
-                              {billMetrics.paidSettlementsCount} settlements ({Math.round(paidPct)}%)
-                            </span>
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          <span className="w-3.5 h-3.5 rounded-full bg-amber-500 flex-shrink-0"></span>
-                          <div className="flex flex-col">
-                            <span className="text-sm font-semibold text-gray-700">Unpaid/Issued</span>
-                            <span className="text-xs font-medium text-[#7A7A7A]">
-                              {billMetrics.unpaidSettlementsCount} settlements ({Math.round(100 - paidPct)}%)
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </>
-                  ) : (
-                    <div className="text-center py-10 space-y-3">
-                      <div className="mx-auto w-16 h-16 text-gray-200 bg-gray-50 rounded-full flex items-center justify-center">
-                        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-                        </svg>
-                      </div>
-                      <p className="text-sm font-semibold text-[#7A7A7A]">No Settlement Data Available</p>
-                    </div>
-                  )}
-                </div>
               </div>
+            </div>
 
-              <div className="bg-white p-6 sm:p-8 rounded-xl border border-[#DACDCA] shadow-sm flex flex-col justify-between h-96">
+            <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
+              <div className="absolute top-0 right-0 w-24 h-24 bg-emerald-500/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
+              <div className="flex flex-col justify-between h-full space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
+                    Occupancy Rate
+                  </span>
+                  <span className="p-2 bg-emerald-100 text-emerald-700 rounded-xl">
+                    <Percent className="w-5 h-5" />
+                  </span>
+                </div>
                 <div>
-                  <h3 className="text-lg font-bold text-[#1A1A1A]">
-                    Financial Volume Summary
-                  </h3>
-                  <p className="text-xs text-[#7A7A7A] mt-1">
-                    Comparison between collected revenue and outstanding receivables.
+                  <h2 className="text-3xl font-extrabold text-[#1A1A1A] tracking-tight flex items-baseline gap-1">
+                    {occupancyRate}%
+                  </h2>
+                  <div className="w-full bg-[#F7F7F7] border border-[#DACDCA] h-2 rounded-full mt-3 overflow-hidden">
+                    <div
+                      className="bg-emerald-600 h-full rounded-full transition-all duration-1000"
+                      style={{ width: `${occupancyRate}%` }}
+                    ></div>
+                  </div>
+                  <p className="text-[10px] text-[#7A7A7A] mt-2 font-medium">
+                    {occupiedDays} total nights ({totalUnitsCount} units monitored)
                   </p>
                 </div>
+              </div>
+            </div>
 
-                <div className="flex flex-col justify-center gap-6 my-auto h-full w-full">
-                  {billMetrics.revenueFromSettlements > 0 || billMetrics.unpaidBalance > 0 ? (
-                    <div className="space-y-6 w-full px-2 pt-6">
-                      
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-sm">
-                          <span className="font-semibold text-gray-700 flex items-center gap-2">
-                            <span className="w-2.5 h-2.5 rounded-full bg-emerald-500"></span>
-                            Collected Revenue
+            <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
+              <div className="absolute top-0 right-0 w-24 h-24 bg-blue-500/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
+              <div className="flex flex-col justify-between h-full space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
+                    Collected Revenue
+                  </span>
+                  <span className="p-2 bg-blue-100 text-blue-700 rounded-xl">
+                    <DollarSign className="w-5 h-5" />
+                  </span>
+                </div>
+                <div>
+                  <h2 className="text-3xl font-extrabold text-[#1A1A1A] tracking-tight">
+                    {revenueFromSettlements.toLocaleString("pl-PL", { style: "currency", currency: "PLN" })}
+                  </h2>
+                  <p className="text-xs text-[#7A7A7A] mt-2 font-medium">
+                    Paid settlements and deposits
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="group bg-white p-6 rounded-xl border border-[#DACDCA] shadow-sm hover:shadow-md transition-all duration-300 transform hover:-translate-y-1 relative overflow-hidden">
+              <div className="absolute top-0 right-0 w-24 h-24 bg-amber-500/5 rounded-bl-full pointer-events-none transition-all duration-300 group-hover:scale-110"></div>
+              <div className="flex flex-col justify-between h-full space-y-4">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">
+                    Outstanding Receivables
+                  </span>
+                  <span className="p-2 bg-amber-100 text-amber-700 rounded-xl">
+                    <Activity className="w-5 h-5" />
+                  </span>
+                </div>
+                <div>
+                  <h2 className="text-3xl font-extrabold text-[#1A1A1A] tracking-tight">
+                    {unpaidBalance.toLocaleString("pl-PL", { style: "currency", currency: "PLN" })}
+                  </h2>
+                  <p className="text-xs text-[#7A7A7A] mt-2 font-medium">
+                    Pending invoice settlements
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 2. Responsive CSS Grid for Core Analytics Charts (recharts) */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            
+            {/* Chart 1: Occupancy Trend (Area Chart) */}
+            <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
+              <div>
+                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
+                  <TrendingUp className="w-5 h-5 text-emerald-600" />
+                  Occupancy Trend
+                </h3>
+                <p className="text-xs text-[#7A7A7A]">
+                  Shows how occupancy percentages fluctuate over the selected range.
+                </p>
+              </div>
+              <div className="h-80 w-full">
+                {chartData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={chartData} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+                      <defs>
+                        <linearGradient id="occupancyGrad" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="5%" stopColor="#10B981" stopOpacity={0.2} />
+                          <stop offset="95%" stopColor="#10B981" stopOpacity={0} />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" vertical={false} />
+                      <XAxis dataKey="label" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} dy={8} />
+                      <YAxis stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} domain={[0, 100]} tickFormatter={(v) => `${v}%`} />
+                      <Tooltip content={<CustomOccupancyTooltip />} />
+                      <Area type="monotone" dataKey="occupancy" stroke="#10B981" strokeWidth={2.5} fillOpacity={1} fill="url(#occupancyGrad)" />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="h-full flex items-center justify-center text-sm font-medium text-gray-400">
+                    No occupancy trend data available
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Chart 2: AI Pricing Effectiveness (Line Chart) */}
+            <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
+              <div>
+                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
+                  <Flame className="w-5 h-5 text-indigo-600" />
+                  AI Pricing Effectiveness
+                </h3>
+                <p className="text-xs text-[#7A7A7A]">
+                  Comparison between the Unit Base Price and actual AI-dynamic price sold.
+                </p>
+              </div>
+              <div className="h-80 w-full">
+                {chartData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={chartData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" vertical={false} />
+                      <XAxis dataKey="label" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} dy={8} />
+                      <YAxis stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `zł${v}`} />
+                      <Tooltip content={<CustomPricingTooltip />} />
+                      <Legend verticalAlign="top" height={36} iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 11, fontWeight: "bold" }} />
+                      <Line type="monotone" dataKey="staticAdr" name="Static Base Price" stroke="#9CA3AF" strokeWidth={2} strokeDasharray="5 5" dot={false} activeDot={{ r: 4 }} />
+                      <Line type="monotone" dataKey="aiAdr" name="AI-Predicted Price" stroke="#6366F1" strokeWidth={2.5} dot={{ r: 3, strokeWidth: 1 }} activeDot={{ r: 6 }} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="h-full flex items-center justify-center text-sm font-medium text-gray-400">
+                    No dynamic pricing data available
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Chart 3: Net Profit & OCR Integration (Composed Chart) */}
+            <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
+              <div>
+                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
+                  <BarChart3 className="w-5 h-5 text-blue-600" />
+                  Net Profit & OCR billing
+                </h3>
+                <p className="text-xs text-[#7A7A7A]">
+                  Gross revenue mapped against OCR-extracted media and utility expenses.
+                </p>
+              </div>
+              <div className="h-80 w-full">
+                {chartData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart data={chartData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" vertical={false} />
+                      <XAxis dataKey="label" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} dy={8} />
+                      <YAxis stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `zł${v}`} />
+                      <Tooltip content={<CustomProfitTooltip />} />
+                      <Legend verticalAlign="top" height={36} iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 11, fontWeight: "bold" }} />
+                      <Bar dataKey="grossRevenue" name="Gross Revenue" fill="#3B82F6" radius={[4, 4, 0, 0]} barSize={20} />
+                      <Bar dataKey="utilityCosts" name="Utility Expenses" fill="#EF4444" radius={[4, 4, 0, 0]} barSize={20} />
+                      <Line type="monotone" dataKey="netProfit" name="Net Profit" stroke="#10B981" strokeWidth={3} dot={{ r: 4 }} />
+                    </ComposedChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="h-full flex items-center justify-center text-sm font-medium text-gray-400">
+                    No financial transaction history in this range
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Chart 4: Unit Performance Ranking (Horizontal Bar Chart) */}
+            <div className="bg-white rounded-xl border border-[#DACDCA] shadow-sm p-6 space-y-4">
+              <div>
+                <h3 className="text-lg font-bold text-[#1A1A1A] flex items-center gap-2">
+                  <Award className="w-5 h-5 text-amber-500" />
+                  Unit Profitability Ranking
+                </h3>
+                <p className="text-xs text-[#7A7A7A]">
+                  Top performing accommodations sorted by gross rental revenue.
+                </p>
+              </div>
+              <div className="h-80 w-full">
+                {rankingData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart
+                      layout="vertical"
+                      data={rankingData}
+                      margin={{ top: 10, right: 10, left: 15, bottom: 5 }}
+                    >
+                      <CartesianGrid strokeDasharray="3 3" stroke="#F1F1F1" horizontal={false} />
+                      <XAxis type="number" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} tickFormatter={(v) => `zł${v}`} />
+                      <YAxis type="category" dataKey="name" stroke="#7A7A7A" fontSize={10} tickLine={false} axisLine={false} width={80} />
+                      <Tooltip content={<CustomRankingTooltip />} />
+                      <Bar dataKey="revenue" name="Total Revenue" fill="#42211D" radius={[0, 4, 4, 0]} barSize={14} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="h-full flex items-center justify-center text-sm font-medium text-gray-400">
+                    No active rentals or units resolved in this range
+                  </div>
+                )}
+              </div>
+            </div>
+
+          </div>
+
+          {/* Bottom Summaries */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 border-t border-[#DACDCA] pt-8">
+            <div className="bg-white p-6 sm:p-8 rounded-xl border border-[#DACDCA] shadow-sm flex flex-col justify-between h-96">
+              <div>
+                <h3 className="text-lg font-bold text-[#1A1A1A]">
+                  Settlements Payment Ratio
+                </h3>
+                <p className="text-xs text-[#7A7A7A] mt-1">
+                  Proportion of paid versus unpaid settlements within date range.
+                </p>
+              </div>
+
+              <div className="flex flex-col sm:flex-row items-center justify-center gap-8 my-auto">
+                {totalSettlements > 0 ? (
+                  <>
+                    <div className="relative w-40 h-40 flex-shrink-0">
+                      <svg className="w-full h-full transform -rotate-90" viewBox="0 0 36 36">
+                        <circle
+                          cx="18"
+                          cy="18"
+                          r="15.915"
+                          fill="none"
+                          stroke="#F7F7F7"
+                          strokeWidth="3.2"
+                        />
+                        <circle
+                          cx="18"
+                          cy="18"
+                          r="15.915"
+                          fill="none"
+                          stroke="#42211D"
+                          strokeWidth="3.2"
+                          strokeDasharray={`${paidPct} ${100 - paidPct}`}
+                          strokeDashoffset="0"
+                          className="transition-all duration-1000 ease-out"
+                        />
+                        <circle
+                          cx="18"
+                          cy="18"
+                          r="15.915"
+                          fill="none"
+                          stroke="#F59E0B"
+                          strokeWidth="3.2"
+                          strokeDasharray={`${(100 - paidPct)} ${paidPct}`}
+                          strokeDashoffset={`-${paidPct}`}
+                          className="transition-all duration-1000 ease-out"
+                        />
+                      </svg>
+                      <div className="absolute inset-0 flex flex-col items-center justify-center">
+                        <span className="text-2xl font-black text-[#1A1A1A]">{totalSettlements}</span>
+                        <span className="text-[10px] uppercase font-bold tracking-widest text-[#7A7A7A]">Total</span>
+                      </div>
+                    </div>
+
+                    <div className="flex flex-col gap-3">
+                      <div className="flex items-center gap-3">
+                        <span className="w-3.5 h-3.5 rounded-full bg-[#42211D] flex-shrink-0"></span>
+                        <div className="flex flex-col">
+                          <span className="text-sm font-semibold text-gray-700">Paid Invoices</span>
+                          <span className="text-xs font-medium text-[#7A7A7A]">
+                            {paidSettlementsCount} settlements ({Math.round(paidPct)}%)
                           </span>
-                          <span className="font-bold text-gray-900">
-                            {billMetrics.revenueFromSettlements.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
-                          </span>
-                        </div>
-                        <div className="w-full bg-[#F7F7F7] border border-[#DACDCA] h-6 rounded-lg overflow-hidden relative shadow-inner">
-                          <div 
-                            className="bg-emerald-500 h-full rounded-lg transition-all duration-1000 ease-out shadow-sm"
-                            style={{ 
-                              width: `${
-                                billMetrics.revenueFromSettlements + billMetrics.unpaidBalance > 0
-                                  ? (billMetrics.revenueFromSettlements / (billMetrics.revenueFromSettlements + billMetrics.unpaidBalance)) * 100
-                                  : 0
-                              }%` 
-                            }}
-                          ></div>
                         </div>
                       </div>
-
-                      <div className="space-y-2">
-                        <div className="flex items-center justify-between text-sm">
-                          <span className="font-semibold text-gray-700 flex items-center gap-2">
-                            <span className="w-2.5 h-2.5 rounded-full bg-amber-500"></span>
-                            Outstanding Receivables
+                      <div className="flex items-center gap-3">
+                        <span className="w-3.5 h-3.5 rounded-full bg-amber-500 flex-shrink-0"></span>
+                        <div className="flex flex-col">
+                          <span className="text-sm font-semibold text-gray-700">Unpaid/Issued</span>
+                          <span className="text-xs font-medium text-[#7A7A7A]">
+                            {unpaidSettlementsCount} settlements ({Math.round(100 - paidPct)}%)
                           </span>
-                          <span className="font-bold text-gray-900">
-                            {billMetrics.unpaidBalance.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
-                          </span>
-                        </div>
-                        <div className="w-full bg-[#F7F7F7] border border-[#DACDCA] h-6 rounded-lg overflow-hidden relative shadow-inner">
-                          <div 
-                            className="bg-amber-500 h-full rounded-lg transition-all duration-1000 ease-out shadow-sm"
-                            style={{ 
-                              width: `${
-                                billMetrics.revenueFromSettlements + billMetrics.unpaidBalance > 0
-                                  ? (billMetrics.unpaidBalance / (billMetrics.revenueFromSettlements + billMetrics.unpaidBalance)) * 100
-                                  : 0
-                              }%` 
-                            }}
-                          ></div>
                         </div>
                       </div>
+                    </div>
+                  </>
+                ) : (
+                  <div className="text-center py-10 space-y-3">
+                    <div className="mx-auto w-16 h-16 text-gray-200 bg-gray-50 rounded-full flex items-center justify-center">
+                      <AlertCircle className="w-8 h-8" />
+                    </div>
+                    <p className="text-sm font-semibold text-[#7A7A7A]">No Settlement Data Available</p>
+                  </div>
+                )}
+              </div>
+            </div>
 
-                      <div className="border-t border-gray-100 pt-4 flex justify-between text-xs text-[#7A7A7A] font-bold">
-                        <span>Total Settlements Volume:</span>
-                        <span>
-                          {(billMetrics.revenueFromSettlements + billMetrics.unpaidBalance).toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+            <div className="bg-white p-6 sm:p-8 rounded-xl border border-[#DACDCA] shadow-sm flex flex-col justify-between h-96">
+              <div>
+                <h3 className="text-lg font-bold text-[#1A1A1A]">
+                  Financial Volume Breakdown
+                </h3>
+                <p className="text-xs text-[#7A7A7A] mt-1">
+                  Collected revenue compared directly to outstanding receivables.
+                </p>
+              </div>
+
+              <div className="flex flex-col justify-center gap-6 my-auto h-full w-full">
+                {revenueFromSettlements > 0 || unpaidBalance > 0 ? (
+                  <div className="space-y-6 w-full px-2 pt-6">
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-semibold text-gray-700 flex items-center gap-2">
+                          <span className="w-2.5 h-2.5 rounded-full bg-emerald-500"></span>
+                          Collected Revenue
+                        </span>
+                        <span className="font-bold text-gray-900">
+                          {revenueFromSettlements.toLocaleString("pl-PL", { style: "currency", currency: "PLN" })}
                         </span>
                       </div>
-
-                    </div>
-                  ) : (
-                    <div className="text-center py-10 space-y-3">
-                      <div className="mx-auto w-16 h-16 text-gray-200 bg-gray-50 rounded-full flex items-center justify-center">
-                        <svg className="w-8 h-8" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
-                        </svg>
+                      <div className="w-full bg-[#F7F7F7] border border-[#DACDCA] h-6 rounded-lg overflow-hidden relative shadow-inner">
+                        <div
+                          className="bg-emerald-500 h-full rounded-lg transition-all duration-1000 ease-out shadow-sm"
+                          style={{
+                            width: `${
+                              revenueFromSettlements + unpaidBalance > 0
+                                ? (revenueFromSettlements / (revenueFromSettlements + unpaidBalance)) * 100
+                                : 0
+                            }%`
+                          }}
+                        ></div>
                       </div>
-                      <p className="text-sm font-semibold text-[#7A7A7A]">No Revenue Data Available</p>
                     </div>
-                  )}
-                </div>
-              </div>
 
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-semibold text-gray-700 flex items-center gap-2">
+                          <span className="w-2.5 h-2.5 rounded-full bg-amber-500"></span>
+                          Outstanding Receivables
+                        </span>
+                        <span className="font-bold text-gray-900">
+                          {unpaidBalance.toLocaleString("pl-PL", { style: "currency", currency: "PLN" })}
+                        </span>
+                      </div>
+                      <div className="w-full bg-[#F7F7F7] border border-[#DACDCA] h-6 rounded-lg overflow-hidden relative shadow-inner">
+                        <div
+                          className="bg-amber-500 h-full rounded-lg transition-all duration-1000 ease-out shadow-sm"
+                          style={{
+                            width: `${
+                              revenueFromSettlements + unpaidBalance > 0
+                                ? (unpaidBalance / (revenueFromSettlements + unpaidBalance)) * 100
+                                : 0
+                            }%`
+                          }}
+                        ></div>
+                      </div>
+                    </div>
+
+                    <div className="border-t border-gray-100 pt-4 flex justify-between text-xs text-[#7A7A7A] font-bold">
+                      <span>Total Settlements Volume:</span>
+                      <span>
+                        {(revenueFromSettlements + unpaidBalance).toLocaleString("pl-PL", { style: "currency", currency: "PLN" })}
+                      </span>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="text-center py-10 space-y-3">
+                    <div className="mx-auto w-16 h-16 text-gray-200 bg-gray-50 rounded-full flex items-center justify-center">
+                      <AlertCircle className="w-8 h-8" />
+                    </div>
+                    <p className="text-sm font-semibold text-[#7A7A7A]">No Revenue Data Available</p>
+                  </div>
+                )}
+              </div>
             </div>
-          </>
-        )}
-      </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string | number;
+}
+
+const CustomOccupancyTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-white p-3.5 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-1">
+        <p className="text-gray-400 font-bold uppercase tracking-wider text-[9px]">{label}</p>
+        <p className="text-sm flex items-center gap-1.5 font-bold text-gray-900">
+          <span className="w-2.5 h-2.5 rounded-full bg-emerald-500"></span>
+          Occupancy: <span className="text-emerald-600 text-base">{payload[0].value}%</span>
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
+const CustomPricingTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+  if (active && payload && payload.length) {
+    const staticVal = payload.find(p => p.dataKey === 'staticAdr')?.value ?? 0;
+    const aiVal = payload.find(p => p.dataKey === 'aiAdr')?.value ?? 0;
+    const diff = Number(aiVal) - Number(staticVal);
+    const pct = Number(staticVal) > 0 ? (diff / Number(staticVal)) * 100 : 0;
+    return (
+      <div className="bg-white p-4 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-2">
+        <p className="text-gray-400 font-bold uppercase tracking-wider text-[9px]">{label}</p>
+        <div className="space-y-1.5">
+          <p className="flex items-center justify-between gap-4 font-semibold text-gray-600">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-full bg-gray-400"></span>
+              Base Static Price:
+            </span>
+            <span>zł{Number(staticVal).toLocaleString("pl-PL", { minimumFractionDigits: 2 })}</span>
+          </p>
+          <p className="flex items-center justify-between gap-4 font-semibold text-indigo-600">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-full bg-indigo-500"></span>
+              AI Sold Price (ADR):
+            </span>
+            <span>zł{Number(aiVal).toLocaleString("pl-PL", { minimumFractionDigits: 2 })}</span>
+          </p>
+          <div className="border-t border-gray-100 pt-1.5 mt-1.5 flex items-center justify-between gap-4 font-bold text-emerald-600">
+            <span>AI Premium Margin:</span>
+            <span>+zł{diff.toLocaleString("pl-PL", { minimumFractionDigits: 2 })} ({pct.toFixed(1)}%)</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return null;
+};
+
+const CustomProfitTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+  if (active && payload && payload.length) {
+    const gross = payload.find(p => p.dataKey === 'grossRevenue')?.value ?? 0;
+    const utilities = payload.find(p => p.dataKey === 'utilityCosts')?.value ?? 0;
+    const net = Number(gross) - Number(utilities);
+    return (
+      <div className="bg-white p-4 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-2">
+        <p className="text-gray-400 font-bold uppercase tracking-wider text-[9px]">{label}</p>
+        <div className="space-y-1.5">
+          <p className="flex items-center justify-between gap-4 font-semibold text-blue-600">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-full bg-blue-500"></span>
+              Gross Revenue:
+            </span>
+            <span>zł{Number(gross).toLocaleString("pl-PL")}</span>
+          </p>
+          <p className="flex items-center justify-between gap-4 font-semibold text-red-600">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-full bg-red-500"></span>
+              Utility Costs (OCR):
+            </span>
+            <span>zł{Number(utilities).toLocaleString("pl-PL")}</span>
+          </p>
+          <div className="border-t border-gray-100 pt-1.5 mt-1.5 flex items-center justify-between gap-4 font-bold text-emerald-600">
+            <span>Net Profit:</span>
+            <span>zł{net.toLocaleString("pl-PL")}</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return null;
+};
+
+const CustomRankingTooltip = ({ active, payload }: CustomTooltipProps) => {
+  if (active && payload && payload.length) {
+    const revenue = payload.find(p => p.dataKey === 'revenue')?.value ?? 0;
+    const itemPayload = payload[0]?.payload || {};
+    const uName = itemPayload.name || "Unknown Unit";
+    const bookings = itemPayload.bookings || 0;
+    return (
+      <div className="bg-white p-3.5 rounded-xl shadow-lg border border-gray-100 text-xs font-semibold space-y-1.5">
+        <p className="text-gray-900 font-extrabold">{uName}</p>
+        <p className="text-sm font-bold text-gray-700 flex justify-between gap-4">
+          <span>Total Revenue:</span>
+          <span className="text-[#42211D]">zł{Number(revenue).toLocaleString("pl-PL")}</span>
+        </p>
+        <p className="text-xs text-gray-500 flex justify-between gap-4">
+          <span>Bookings Count:</span>
+          <span>{bookings} stay{bookings === 1 ? "" : "s"}</span>
+        </p>
+      </div>
+    );
+  }
+  return null;
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,4 +8,8 @@ export default defineConfig({
     react(),
     tailwindcss()
   ],
+  build: {
+    minify: 'esbuild'
+  }
 })
+

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,14 +2,39 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-// https://vite.dev/config/
+function viteEsToolkitPlugin() {
+  return {
+    name: 'es-toolkit-compat-vite',
+    enforce: 'pre',
+    resolveId(source: string) {
+      if (source.startsWith('es-toolkit/compat/')) {
+        const name = source.split('/').pop() || '';
+        return `\0virtual:es-toolkit-compat:${name}`;
+      }
+      return null;
+    },
+    load(id: string) {
+      if (id.startsWith('\0virtual:es-toolkit-compat:')) {
+        const name = id.replace('\0virtual:es-toolkit-compat:', '');
+        return `export { ${name} as default } from 'es-toolkit/compat';`;
+      }
+      return null;
+    }
+  };
+}
+
 export default defineConfig({
   plugins: [
+    viteEsToolkitPlugin(),
     react(),
     tailwindcss()
   ],
+  optimizeDeps: {
+    rolldownOptions: {
+      plugins: [viteEsToolkitPlugin()]
+    }
+  },
   build: {
     minify: 'esbuild'
   }
 })
-


### PR DESCRIPTION
## Summary
This pull request resolves a critical runtime crash (white screen of death) on the frontend application caused by a bundler namespace collision inside Vite (Rolldown/esbuild) when pre-bundling `recharts`' dependencies (`es-toolkit/compat/*`). It also addresses UI requests for custom tooltip styling (solid white backgrounds, removing double-containers) and chart header icon cleanup on the dashboard page.

## Linked issue
Closes #119 

## Scope of changes
Describe the main changes included in this pull request.
- **Vite Configuration ([vite.config.ts](file:///c:/Users/alicj/Documents/GitHub/KWATERA/frontend/vite.config.ts))**:
  - Implemented `viteEsToolkitPlugin`, which dynamically intercepts all imports from `es-toolkit/compat/*` (e.g., `get`, `uniqBy`, `omit`, `range`) and resolves them in-memory to virtual ES modules.
  - Registered the plugin in both the main Vite pipeline and `optimizeDeps.rolldownOptions.plugins` for dependency pre-bundling. This systematically fixes the CommonJS variable collision (`require_isUnsafeProperty is not a function`, `require_ary is not a function`, etc.) without polluting the filesystem with physical shim files.
- **Dashboard Page ([src/pages/DashboardPage.tsx](file:///c:/Users/alicj/Documents/GitHub/KWATERA/frontend/src/pages/DashboardPage.tsx))**:
  - Removed chart header icons (`TrendingUp`, `Flame`, `BarChart3`, `Award`) along with their unused imports to clean up the layout and comply with TypeScript's unused locals checks.
  - Added explicit inline styling `style={{ backgroundColor: '#ffffff' }}` to all custom tooltip containers to ensure a solid white background, bypassing any potential Tailwind CSS v4 custom property overrides.
  - Customised the Recharts `<Tooltip>` components with `wrapperStyle={{ backgroundColor: 'transparent', border: 'none', outline: 'none' }}` to remove the default outer grey border and padding.

## Testing status
Describe how this was verified.
- [x] Tested locally
- [x] Existing tests pass

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Ready for review