### PR TITLE
Add manual/block UI and blocked reservation support

### DIFF
--- a/frontend/src/api/availabilityApi.ts
+++ b/frontend/src/api/availabilityApi.ts
@@ -13,3 +13,39 @@ export async function getOccupiedDates(unitId: string) {
     const res = await fetch(`${API_URL}/availability/occupied-dates?unitId=${unitId}`);
     return res.json();
 }
+
+export async function createBlock(
+    unitId: string,
+    from: string,
+    to: string,
+    reason: string
+) {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+        throw new Error("Log in to block dates");
+    }
+
+    const res = await fetch(`${GATEWAY_BASE_URL}/api/v1/reservations`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`
+        },
+        body: JSON.stringify({
+            unitId: unitId,
+            startDate: from,
+            endDate: to,
+            currency: "PLN",
+            status: "BLOCKED",
+            reason: reason // send reason directly or inside body
+        })
+    });
+
+    if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(errorData.message || "Failed to block dates");
+    }
+
+    return res.json();
+}

--- a/frontend/src/api/reservationApi.ts
+++ b/frontend/src/api/reservationApi.ts
@@ -38,6 +38,49 @@ export async function createReservation(
     return res.json();
 }
 
+export async function createManualReservation(
+    unitId: string,
+    from: string,
+    to: string,
+    guestEmail: string,
+    guestDetails: {
+        firstName: string;
+        lastName: string;
+        phone: string;
+        note?: string;
+    }
+) {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+        throw new Error("Log in to create a manual reservation");
+    }
+
+    const res = await fetch(API_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`
+        },
+        body: JSON.stringify({
+            unitId: unitId,
+            startDate: from,
+            endDate: to,
+            currency: "PLN",
+            guestEmail: guestEmail,
+            status: "CONFIRMED",
+            ...guestDetails
+        })
+    });
+
+    if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(errorData.message || "Failed to create manual reservation");
+    }
+
+    return res.json();
+}
+
 export async function getReservationDetails(id: string) {
     const token = localStorage.getItem("token");
 

--- a/frontend/src/components/BlockDatesModal.tsx
+++ b/frontend/src/components/BlockDatesModal.tsx
@@ -1,6 +1,17 @@
 import React, { useState } from "react";
 import { createBlock } from "../api/availabilityApi";
 import { format } from "date-fns";
+import SharedDatePicker from "./SharedDatePicker";
+
+const parseDateString = (str: string): Date | null => {
+    if (!str) return null;
+    const parts = str.split("-");
+    if (parts.length !== 3) return null;
+    const year = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10) - 1;
+    const day = parseInt(parts[2], 10);
+    return new Date(year, month, day);
+};
 
 interface Unit {
     id: string;
@@ -200,30 +211,47 @@ export default function BlockDatesModal({
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-1">
                             <label htmlFor="checkIn" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Start Date</label>
-                            <input
-                                type="date"
-                                id="checkIn"
-                                name="checkIn"
-                                value={form.checkIn}
-                                onChange={handleChange}
-                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                            <SharedDatePicker
+                                selected={parseDateString(form.checkIn)}
+                                onChange={(date) => {
+                                    const formatted = date ? format(date, "yyyy-MM-dd") : "";
+                                    setForm(prev => ({ ...prev, checkIn: formatted }));
+                                    if (errors.checkIn) {
+                                        setErrors(prev => ({ ...prev, checkIn: undefined }));
+                                    }
+                                }}
+                                selectsStart
+                                startDate={parseDateString(form.checkIn)}
+                                endDate={parseDateString(form.checkOut)}
+                                placeholderText="Select start date"
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-semibold cursor-pointer text-left ${
                                     errors.checkIn ? "border-red-500" : "border-brand-accent"
                                 }`}
+                                wrapperClassName="w-full"
                             />
                             {errors.checkIn && <p className="text-xs font-semibold text-red-500">{errors.checkIn}</p>}
                         </div>
 
                         <div className="grid grid-cols-1 space-y-1">
                             <label htmlFor="checkOut" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">End Date</label>
-                            <input
-                                type="date"
-                                id="checkOut"
-                                name="checkOut"
-                                value={form.checkOut}
-                                onChange={handleChange}
-                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                            <SharedDatePicker
+                                selected={parseDateString(form.checkOut)}
+                                onChange={(date) => {
+                                    const formatted = date ? format(date, "yyyy-MM-dd") : "";
+                                    setForm(prev => ({ ...prev, checkOut: formatted }));
+                                    if (errors.checkOut) {
+                                        setErrors(prev => ({ ...prev, checkOut: undefined }));
+                                    }
+                                }}
+                                selectsEnd
+                                startDate={parseDateString(form.checkIn)}
+                                endDate={parseDateString(form.checkOut)}
+                                minDate={parseDateString(form.checkIn)}
+                                placeholderText="Select end date"
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-semibold cursor-pointer text-left ${
                                     errors.checkOut ? "border-red-500" : "border-brand-accent"
                                 }`}
+                                wrapperClassName="w-full"
                             />
                             {errors.checkOut && <p className="text-xs font-semibold text-red-500">{errors.checkOut}</p>}
                         </div>

--- a/frontend/src/components/BlockDatesModal.tsx
+++ b/frontend/src/components/BlockDatesModal.tsx
@@ -1,0 +1,280 @@
+import React, { useState } from "react";
+import { createBlock } from "../api/availabilityApi";
+import { format } from "date-fns";
+
+interface Unit {
+    id: string;
+    name: string;
+}
+
+interface Occupancy {
+    reservationId: string;
+    unitId: string;
+    unitName?: string;
+    startDate: string;
+    endDate: string;
+    status: string;
+    guestName?: string;
+    totalPrice?: number;
+}
+
+const getOccupiedRange = (startDateStr: string, endDateStr: string) => {
+    if (startDateStr < endDateStr) {
+        const parts = endDateStr.split('-');
+        const y = parseInt(parts[0], 10);
+        const m = parseInt(parts[1], 10) - 1;
+        const d = parseInt(parts[2], 10);
+        const endDate = new Date(y, m, d);
+        endDate.setDate(endDate.getDate() - 1);
+        
+        const yyyy = endDate.getFullYear();
+        const mm = String(endDate.getMonth() + 1).padStart(2, '0');
+        const dd = String(endDate.getDate()).padStart(2, '0');
+        return { start: startDateStr, end: `${yyyy}-${mm}-${dd}` };
+    }
+    return { start: startDateStr, end: startDateStr };
+};
+
+const checkOverlap = (start1: string, end1: string, start2: string, end2: string): boolean => {
+    const range1 = getOccupiedRange(start1, end1);
+    const range2 = getOccupiedRange(start2, end2);
+    return range1.start <= range2.end && range2.start <= range1.end;
+};
+
+interface BlockDatesModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSuccess: () => void;
+    units: Unit[];
+    initialStartDate?: Date | null;
+    occupancies: Occupancy[];
+}
+
+interface BlockForm {
+    unitId: string;
+    checkIn: string;
+    checkOut: string;
+    reason: string;
+}
+
+interface FormErrors {
+    unitId?: string;
+    checkIn?: string;
+    checkOut?: string;
+    reason?: string;
+}
+
+export default function BlockDatesModal({
+    isOpen,
+    onClose,
+    onSuccess,
+    units,
+    initialStartDate,
+    occupancies
+}: BlockDatesModalProps) {
+    const [form, setForm] = useState<BlockForm>(() => ({
+        unitId: units[0]?.id || "",
+        checkIn: initialStartDate ? format(initialStartDate, "yyyy-MM-dd") : "",
+        checkOut: initialStartDate ? format(initialStartDate, "yyyy-MM-dd") : "",
+        reason: ""
+    }));
+
+    const [errors, setErrors] = useState<FormErrors>({});
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    if (!isOpen) return null;
+
+    const validate = (): boolean => {
+        const tempErrors: FormErrors = {};
+        if (!form.unitId) tempErrors.unitId = "Please select a unit";
+        
+        if (!form.checkIn) {
+            tempErrors.checkIn = "Start date is required";
+        }
+
+        if (!form.checkOut) {
+            tempErrors.checkOut = "End date is required";
+        } else if (form.checkIn && form.checkOut < form.checkIn) {
+            tempErrors.checkOut = "End date cannot be before start date";
+        } else if (form.unitId && form.checkIn && form.checkOut) {
+            const hasOverlap = occupancies.some(occ => {
+                if (occ.unitId !== form.unitId) return false;
+                if (occ.status === "CANCELLED" || occ.status === "COMPLETED") return false;
+                return checkOverlap(form.checkIn, form.checkOut, occ.startDate, occ.endDate);
+            });
+            if (hasOverlap) {
+                tempErrors.checkIn = "Selected dates overlap with an existing booking or block";
+                tempErrors.checkOut = "Selected dates overlap with an existing booking or block";
+            }
+        }
+
+        if (!form.reason.trim()) {
+            tempErrors.reason = "Please provide a reason for blocking these dates";
+        } else if (form.reason.trim().length < 3) {
+            tempErrors.reason = "Reason must be at least 3 characters";
+        }
+
+        setErrors(tempErrors);
+        return Object.keys(tempErrors).length === 0;
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+        const { name, value } = e.target;
+        setForm(prev => ({ ...prev, [name]: value }));
+        if (errors[name as keyof FormErrors]) {
+            setErrors(prev => ({ ...prev, [name]: undefined }));
+        }
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!validate()) return;
+
+        setIsSubmitting(true);
+        setSubmitError(null);
+
+        try {
+            await createBlock(
+                form.unitId,
+                form.checkIn,
+                form.checkOut,
+                form.reason.trim()
+            );
+            onSuccess();
+            onClose();
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : "Failed to block selected dates.";
+            setSubmitError(msg);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-[9998] flex items-center justify-center p-4">
+            <div className="fixed inset-0 bg-black/50 backdrop-blur-sm transition-opacity" onClick={onClose} />
+            
+            <div className="relative bg-[#FFFFFF] rounded-2xl shadow-2xl border border-brand-accent w-full max-w-md overflow-hidden flex flex-col z-[9999] animate-in fade-in zoom-in-95 duration-200">
+                <div className="px-6 py-5 border-b border-brand-accent flex items-center justify-between">
+                    <div>
+                        <h2 className="text-xl font-black text-brand-main tracking-tight">Block Dates</h2>
+                        <p className="text-xs text-brand-muted mt-0.5">Mark a room as unavailable for maintenance or other reasons.</p>
+                    </div>
+                    <button onClick={onClose} className="p-2 text-brand-muted hover:text-brand-main hover:bg-brand-bg rounded-full transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="p-6 space-y-5">
+                    {submitError && (
+                        <div className="p-4 bg-red-50 border-l-4 border-red-500 rounded-r-xl text-red-700 text-sm font-semibold flex gap-2">
+                            <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd"/>
+                            </svg>
+                            <span>{submitError}</span>
+                        </div>
+                    )}
+
+                    <div className="space-y-1">
+                        <label htmlFor="unitId" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Property Unit</label>
+                        <select
+                            id="unitId"
+                            name="unitId"
+                            value={form.unitId}
+                            onChange={handleChange}
+                            className={`w-full px-4 py-2.5 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all font-semibold ${
+                                errors.unitId ? "border-red-500" : "border-brand-accent"
+                            }`}
+                        >
+                            <option value="">Select Unit...</option>
+                            {units.map(unit => (
+                                <option key={unit.id} value={unit.id}>{unit.name}</option>
+                            ))}
+                        </select>
+                        {errors.unitId && <p className="text-xs font-semibold text-red-500">{errors.unitId}</p>}
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-1">
+                            <label htmlFor="checkIn" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Start Date</label>
+                            <input
+                                type="date"
+                                id="checkIn"
+                                name="checkIn"
+                                value={form.checkIn}
+                                onChange={handleChange}
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                    errors.checkIn ? "border-red-500" : "border-brand-accent"
+                                }`}
+                            />
+                            {errors.checkIn && <p className="text-xs font-semibold text-red-500">{errors.checkIn}</p>}
+                        </div>
+
+                        <div className="grid grid-cols-1 space-y-1">
+                            <label htmlFor="checkOut" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">End Date</label>
+                            <input
+                                type="date"
+                                id="checkOut"
+                                name="checkOut"
+                                value={form.checkOut}
+                                onChange={handleChange}
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                    errors.checkOut ? "border-red-500" : "border-brand-accent"
+                                }`}
+                            />
+                            {errors.checkOut && <p className="text-xs font-semibold text-red-500">{errors.checkOut}</p>}
+                        </div>
+                    </div>
+
+                    <div className="space-y-1">
+                        <label htmlFor="reason" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Reason for block</label>
+                        <textarea
+                            id="reason"
+                            name="reason"
+                            value={form.reason}
+                            onChange={handleChange}
+                            rows={3}
+                            placeholder="e.g., General maintenance, private use, repaint walls..."
+                            className={`w-full px-4 py-2.5 border rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm resize-none ${
+                                errors.reason ? "border-red-500" : "border-brand-accent"
+                            }`}
+                        />
+                        {errors.reason && <p className="text-xs font-semibold text-red-500">{errors.reason}</p>}
+                    </div>
+
+                    <div className="pt-4 border-t border-brand-accent flex items-center justify-end gap-3 bg-[#FFFFFF]">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="px-4 py-2.5 border border-brand-accent rounded-lg text-brand-main font-bold hover:bg-gray-50 text-sm transition"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isSubmitting}
+                            className={`px-5 py-2.5 bg-brand-primary text-white font-bold text-sm rounded-lg hover:bg-brand-primary-hover shadow-sm transition flex items-center justify-center gap-1.5 ${
+                                isSubmitting ? "opacity-75 cursor-wait" : ""
+                            }`}
+                        >
+                            {isSubmitting ? (
+                                <>
+                                    <svg className="animate-spin h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                    </svg>
+                                    Blocking Dates...
+                                </>
+                            ) : (
+                                "Apply Block"
+                            )}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/ManualReservationModal.tsx
+++ b/frontend/src/components/ManualReservationModal.tsx
@@ -1,6 +1,17 @@
 import React, { useState } from "react";
 import { createManualReservation } from "../api/reservationApi";
 import { format, isAfter, addDays } from "date-fns";
+import SharedDatePicker from "./SharedDatePicker";
+
+const parseDateString = (str: string): Date | null => {
+    if (!str) return null;
+    const parts = str.split("-");
+    if (parts.length !== 3) return null;
+    const year = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10) - 1;
+    const day = parseInt(parts[2], 10);
+    return new Date(year, month, day);
+};
 
 interface Unit {
     id: string;
@@ -237,30 +248,47 @@ export default function ManualReservationModal({
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-1">
                             <label htmlFor="checkIn" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Check-In</label>
-                            <input
-                                type="date"
-                                id="checkIn"
-                                name="checkIn"
-                                value={form.checkIn}
-                                onChange={handleChange}
-                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                            <SharedDatePicker
+                                selected={parseDateString(form.checkIn)}
+                                onChange={(date) => {
+                                    const formatted = date ? format(date, "yyyy-MM-dd") : "";
+                                    setForm(prev => ({ ...prev, checkIn: formatted }));
+                                    if (errors.checkIn) {
+                                        setErrors(prev => ({ ...prev, checkIn: undefined }));
+                                    }
+                                }}
+                                selectsStart
+                                startDate={parseDateString(form.checkIn)}
+                                endDate={parseDateString(form.checkOut)}
+                                placeholderText="Select check-in"
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-semibold cursor-pointer text-left ${
                                     errors.checkIn ? "border-red-500" : "border-brand-accent"
                                 }`}
+                                wrapperClassName="w-full"
                             />
                             {errors.checkIn && <p className="text-xs font-semibold text-red-500">{errors.checkIn}</p>}
                         </div>
 
                         <div className="space-y-1">
                             <label htmlFor="checkOut" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Check-Out</label>
-                            <input
-                                type="date"
-                                id="checkOut"
-                                name="checkOut"
-                                value={form.checkOut}
-                                onChange={handleChange}
-                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                            <SharedDatePicker
+                                selected={parseDateString(form.checkOut)}
+                                onChange={(date) => {
+                                    const formatted = date ? format(date, "yyyy-MM-dd") : "";
+                                    setForm(prev => ({ ...prev, checkOut: formatted }));
+                                    if (errors.checkOut) {
+                                        setErrors(prev => ({ ...prev, checkOut: undefined }));
+                                    }
+                                }}
+                                selectsEnd
+                                startDate={parseDateString(form.checkIn)}
+                                endDate={parseDateString(form.checkOut)}
+                                minDate={parseDateString(form.checkIn)}
+                                placeholderText="Select check-out"
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-semibold cursor-pointer text-left ${
                                     errors.checkOut ? "border-red-500" : "border-brand-accent"
                                 }`}
+                                wrapperClassName="w-full"
                             />
                             {errors.checkOut && <p className="text-xs font-semibold text-red-500">{errors.checkOut}</p>}
                         </div>

--- a/frontend/src/components/ManualReservationModal.tsx
+++ b/frontend/src/components/ManualReservationModal.tsx
@@ -1,0 +1,383 @@
+import React, { useState } from "react";
+import { createManualReservation } from "../api/reservationApi";
+import { format, isAfter, addDays } from "date-fns";
+
+interface Unit {
+    id: string;
+    name: string;
+}
+
+interface Occupancy {
+    reservationId: string;
+    unitId: string;
+    unitName?: string;
+    startDate: string;
+    endDate: string;
+    status: string;
+    guestName?: string;
+    totalPrice?: number;
+}
+
+const getOccupiedRange = (startDateStr: string, endDateStr: string) => {
+    if (startDateStr < endDateStr) {
+        const parts = endDateStr.split('-');
+        const y = parseInt(parts[0], 10);
+        const m = parseInt(parts[1], 10) - 1;
+        const d = parseInt(parts[2], 10);
+        const endDate = new Date(y, m, d);
+        endDate.setDate(endDate.getDate() - 1);
+        
+        const yyyy = endDate.getFullYear();
+        const mm = String(endDate.getMonth() + 1).padStart(2, '0');
+        const dd = String(endDate.getDate()).padStart(2, '0');
+        return { start: startDateStr, end: `${yyyy}-${mm}-${dd}` };
+    }
+    return { start: startDateStr, end: startDateStr };
+};
+
+const checkOverlap = (start1: string, end1: string, start2: string, end2: string): boolean => {
+    const range1 = getOccupiedRange(start1, end1);
+    const range2 = getOccupiedRange(start2, end2);
+    return range1.start <= range2.end && range2.start <= range1.end;
+};
+
+interface ManualReservationModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSuccess: () => void;
+    units: Unit[];
+    initialStartDate?: Date | null;
+    occupancies: Occupancy[];
+}
+
+interface ReservationForm {
+    unitId: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+    checkIn: string;
+    checkOut: string;
+    note: string;
+}
+
+interface FormErrors {
+    unitId?: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    checkIn?: string;
+    checkOut?: string;
+}
+
+export default function ManualReservationModal({
+    isOpen,
+    onClose,
+    onSuccess,
+    units,
+    initialStartDate,
+    occupancies
+}: ManualReservationModalProps) {
+    const [form, setForm] = useState<ReservationForm>(() => ({
+        unitId: units[0]?.id || "",
+        firstName: "",
+        lastName: "",
+        email: "",
+        phone: "",
+        checkIn: initialStartDate ? format(initialStartDate, "yyyy-MM-dd") : "",
+        checkOut: initialStartDate ? format(addDays(initialStartDate, 1), "yyyy-MM-dd") : "",
+        note: ""
+    }));
+
+    const [errors, setErrors] = useState<FormErrors>({});
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    if (!isOpen) return null;
+
+    const validate = (): boolean => {
+        const tempErrors: FormErrors = {};
+        if (!form.unitId) tempErrors.unitId = "Please select a unit";
+        
+        if (!form.firstName.trim()) {
+            tempErrors.firstName = "First name is required";
+        } else if (form.firstName.trim().length < 2) {
+            tempErrors.firstName = "Must be at least 2 characters";
+        }
+
+        if (!form.lastName.trim()) {
+            tempErrors.lastName = "Last name is required";
+        } else if (form.lastName.trim().length < 2) {
+            tempErrors.lastName = "Must be at least 2 characters";
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!form.email.trim()) {
+            tempErrors.email = "Email is required";
+        } else if (!emailRegex.test(form.email)) {
+            tempErrors.email = "Enter a valid email address";
+        }
+
+        const phoneRegex = /^\+?[0-9\s\-()]{7,20}$/;
+        if (!form.phone.trim()) {
+            tempErrors.phone = "Phone number is required";
+        } else if (!phoneRegex.test(form.phone)) {
+            tempErrors.phone = "Enter a valid phone number";
+        }
+
+        if (!form.checkIn) {
+            tempErrors.checkIn = "Check-in date is required";
+        }
+
+        if (!form.checkOut) {
+            tempErrors.checkOut = "Check-out date is required";
+        } else if (form.checkIn && !isAfter(new Date(form.checkOut), new Date(form.checkIn))) {
+            tempErrors.checkOut = "Check-out must be after check-in";
+        } else if (form.unitId && form.checkIn && form.checkOut) {
+            const hasOverlap = occupancies.some(occ => {
+                if (occ.unitId !== form.unitId) return false;
+                if (occ.status === "CANCELLED" || occ.status === "COMPLETED") return false;
+                return checkOverlap(form.checkIn, form.checkOut, occ.startDate, occ.endDate);
+            });
+            if (hasOverlap) {
+                tempErrors.checkIn = "Selected dates overlap with an existing booking or block";
+                tempErrors.checkOut = "Selected dates overlap with an existing booking or block";
+            }
+        }
+
+        setErrors(tempErrors);
+        return Object.keys(tempErrors).length === 0;
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+        const { name, value } = e.target;
+        setForm(prev => ({ ...prev, [name]: value }));
+        if (errors[name as keyof FormErrors]) {
+            setErrors(prev => ({ ...prev, [name]: undefined }));
+        }
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!validate()) return;
+
+        setIsSubmitting(true);
+        setSubmitError(null);
+
+        try {
+            await createManualReservation(
+                form.unitId,
+                form.checkIn,
+                form.checkOut,
+                form.email.trim(),
+                {
+                    firstName: form.firstName.trim(),
+                    lastName: form.lastName.trim(),
+                    phone: form.phone.trim(),
+                    note: form.note.trim() || undefined
+                }
+            );
+            onSuccess();
+            onClose();
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : "Failed to create manual reservation.";
+            setSubmitError(msg);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-[9998] flex items-center justify-center p-4">
+            <div className="fixed inset-0 bg-black/50 backdrop-blur-sm transition-opacity" onClick={onClose} />
+            
+            <div className="relative bg-[#FFFFFF] rounded-2xl shadow-2xl border border-brand-accent w-full max-w-lg overflow-hidden flex flex-col z-[9999] animate-in fade-in zoom-in-95 duration-200">
+                <div className="px-6 py-5 border-b border-brand-accent flex items-center justify-between">
+                    <div>
+                        <h2 className="text-xl font-black text-brand-main tracking-tight">Add Manual Reservation</h2>
+                        <p className="text-xs text-brand-muted mt-0.5">Book a room directly bypassing Stripe payment flow.</p>
+                    </div>
+                    <button onClick={onClose} className="p-2 text-brand-muted hover:text-brand-main hover:bg-brand-bg rounded-full transition-colors">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-5 max-h-[75vh]">
+                    {submitError && (
+                        <div className="p-4 bg-red-50 border-l-4 border-red-500 rounded-r-xl text-red-700 text-sm font-semibold flex gap-2">
+                            <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd"/>
+                            </svg>
+                            <span>{submitError}</span>
+                        </div>
+                    )}
+
+                    <div className="space-y-1">
+                        <label htmlFor="unitId" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Property Unit</label>
+                        <select
+                            id="unitId"
+                            name="unitId"
+                            value={form.unitId}
+                            onChange={handleChange}
+                            className={`w-full px-4 py-2.5 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all font-semibold ${
+                                errors.unitId ? "border-red-500" : "border-brand-accent"
+                            }`}
+                        >
+                            <option value="">Select Unit...</option>
+                            {units.map(unit => (
+                                <option key={unit.id} value={unit.id}>{unit.name}</option>
+                            ))}
+                        </select>
+                        {errors.unitId && <p className="text-xs font-semibold text-red-500">{errors.unitId}</p>}
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-1">
+                            <label htmlFor="checkIn" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Check-In</label>
+                            <input
+                                type="date"
+                                id="checkIn"
+                                name="checkIn"
+                                value={form.checkIn}
+                                onChange={handleChange}
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                    errors.checkIn ? "border-red-500" : "border-brand-accent"
+                                }`}
+                            />
+                            {errors.checkIn && <p className="text-xs font-semibold text-red-500">{errors.checkIn}</p>}
+                        </div>
+
+                        <div className="space-y-1">
+                            <label htmlFor="checkOut" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Check-Out</label>
+                            <input
+                                type="date"
+                                id="checkOut"
+                                name="checkOut"
+                                value={form.checkOut}
+                                onChange={handleChange}
+                                className={`w-full px-4 py-2 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                    errors.checkOut ? "border-red-500" : "border-brand-accent"
+                                }`}
+                            />
+                            {errors.checkOut && <p className="text-xs font-semibold text-red-500">{errors.checkOut}</p>}
+                        </div>
+                    </div>
+
+                    <div className="border-t border-brand-accent/50 pt-4 space-y-4">
+                        <h3 className="text-sm font-black text-brand-main uppercase tracking-wider">Guest Information</h3>
+                        
+                        <div className="grid grid-cols-2 gap-4">
+                            <div className="space-y-1">
+                                <label htmlFor="firstName" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">First Name</label>
+                                <input
+                                    type="text"
+                                    id="firstName"
+                                    name="firstName"
+                                    value={form.firstName}
+                                    onChange={handleChange}
+                                    className={`w-full px-4 py-2.5 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                        errors.firstName ? "border-red-500" : "border-brand-accent"
+                                    }`}
+                                />
+                                {errors.firstName && <p className="text-xs font-semibold text-red-500">{errors.firstName}</p>}
+                            </div>
+
+                            <div className="space-y-1">
+                                <label htmlFor="lastName" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Last Name</label>
+                                <input
+                                    type="text"
+                                    id="lastName"
+                                    name="lastName"
+                                    value={form.lastName}
+                                    onChange={handleChange}
+                                    className={`w-full px-4 py-2.5 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                        errors.lastName ? "border-red-500" : "border-brand-accent"
+                                    }`}
+                                />
+                                {errors.lastName && <p className="text-xs font-semibold text-red-500">{errors.lastName}</p>}
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-4">
+                            <div className="space-y-1">
+                                <label htmlFor="email" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Email Address</label>
+                                <input
+                                    type="email"
+                                    id="email"
+                                    name="email"
+                                    value={form.email}
+                                    onChange={handleChange}
+                                    className={`w-full px-4 py-2.5 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                        errors.email ? "border-red-500" : "border-brand-accent"
+                                    }`}
+                                />
+                                {errors.email && <p className="text-xs font-semibold text-red-500">{errors.email}</p>}
+                            </div>
+
+                            <div className="space-y-1">
+                                <label htmlFor="phone" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Phone Number</label>
+                                <input
+                                    type="tel"
+                                    id="phone"
+                                    name="phone"
+                                    value={form.phone}
+                                    onChange={handleChange}
+                                    placeholder="+48 123 456 789"
+                                    className={`w-full px-4 py-2.5 border rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm font-medium ${
+                                        errors.phone ? "border-red-500" : "border-brand-accent"
+                                    }`}
+                                />
+                                {errors.phone && <p className="text-xs font-semibold text-red-500">{errors.phone}</p>}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="space-y-1 border-t border-brand-accent/50 pt-4">
+                        <label htmlFor="note" className="block text-xs font-bold text-brand-muted uppercase tracking-wider">Internal Note (Optional)</label>
+                        <textarea
+                            id="note"
+                            name="note"
+                            value={form.note}
+                            onChange={handleChange}
+                            rows={3}
+                            placeholder="Add any internal details, guest preferences, or special requests..."
+                            className="w-full px-4 py-2 border border-brand-accent rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-all text-sm resize-none"
+                        />
+                    </div>
+
+                    <div className="pt-4 border-t border-brand-accent flex items-center justify-end gap-3 bg-[#FFFFFF]">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="px-4 py-2.5 border border-brand-accent rounded-lg text-brand-main font-bold hover:bg-gray-50 text-sm transition"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isSubmitting}
+                            className={`px-5 py-2.5 bg-brand-primary text-white font-bold text-sm rounded-lg hover:bg-brand-primary-hover shadow-sm transition flex items-center justify-center gap-1.5 ${
+                                isSubmitting ? "opacity-75 cursor-wait" : ""
+                            }`}
+                        >
+                            {isSubmitting ? (
+                                <>
+                                    <svg className="animate-spin h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                    </svg>
+                                    Creating Booking...
+                                </>
+                            ) : (
+                                "Confirm Reservation"
+                            )}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/SharedDatePicker.tsx
+++ b/frontend/src/components/SharedDatePicker.tsx
@@ -14,6 +14,8 @@ interface SharedDatePickerProps {
     className?: string;
     dateFormat?: string;
     datepickerRef?: React.RefObject<DatePicker | null>;
+    wrapperClassName?: string;
+    popperPlacement?: string;
 }
 
 const MONTHS = [
@@ -158,7 +160,9 @@ export default function SharedDatePicker({
     placeholderText,
     className,
     dateFormat,
-    datepickerRef
+    datepickerRef,
+    wrapperClassName,
+    popperPlacement
 }: SharedDatePickerProps) {
     return (
         <DatePicker
@@ -177,6 +181,11 @@ export default function SharedDatePicker({
             calendarClassName="bg-white border border-gray-200 shadow-xl rounded-lg custom-datepicker-has-header"
             popperClassName="z-[9999]"
             calendarStartDay={1}
+            wrapperClassName={wrapperClassName}
+            popperPlacement={popperPlacement as any}
+            popperProps={{
+                strategy: "fixed"
+            }}
         />
     );
 }

--- a/frontend/src/components/SharedDatePicker.tsx
+++ b/frontend/src/components/SharedDatePicker.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import type { ComponentProps } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
@@ -15,22 +16,7 @@ interface SharedDatePickerProps {
     dateFormat?: string;
     datepickerRef?: React.RefObject<DatePicker | null>;
     wrapperClassName?: string;
-    popperPlacement?:
-        | "top"
-        | "top-start"
-        | "top-end"
-        | "bottom"
-        | "bottom-start"
-        | "bottom-end"
-        | "left"
-        | "left-start"
-        | "left-end"
-        | "right"
-        | "right-start"
-        | "right-end"
-        | "auto"
-        | "auto-left"
-        | "auto-right";
+    popperPlacement?: ComponentProps<typeof DatePicker>["popperPlacement"];
 }
 
 const MONTHS = [

--- a/frontend/src/components/SharedDatePicker.tsx
+++ b/frontend/src/components/SharedDatePicker.tsx
@@ -15,7 +15,22 @@ interface SharedDatePickerProps {
     dateFormat?: string;
     datepickerRef?: React.RefObject<DatePicker | null>;
     wrapperClassName?: string;
-    popperPlacement?: string;
+    popperPlacement?:
+        | "top"
+        | "top-start"
+        | "top-end"
+        | "bottom"
+        | "bottom-start"
+        | "bottom-end"
+        | "left"
+        | "left-start"
+        | "left-end"
+        | "right"
+        | "right-start"
+        | "right-end"
+        | "auto"
+        | "auto-left"
+        | "auto-right";
 }
 
 const MONTHS = [
@@ -182,7 +197,7 @@ export default function SharedDatePicker({
             popperClassName="z-[9999]"
             calendarStartDay={1}
             wrapperClassName={wrapperClassName}
-            popperPlacement={popperPlacement as any}
+            popperPlacement={popperPlacement}
             popperProps={{
                 strategy: "fixed"
             }}

--- a/frontend/src/pages/OccupancyCalendarPage.tsx
+++ b/frontend/src/pages/OccupancyCalendarPage.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { getOccupancy } from "../api/adminApi";
 import { format, addDays, startOfToday, isAfter, isBefore, startOfWeek, endOfWeek, startOfMonth, endOfMonth, addMonths } from "date-fns";
 import SharedDatePicker from "../components/SharedDatePicker";
+import ManualReservationModal from "../components/ManualReservationModal";
+import BlockDatesModal from "../components/BlockDatesModal";
 
 interface Occupancy {
     reservationId: string;
@@ -24,6 +26,10 @@ export default function OccupancyCalendarPage() {
     const [startDate] = dateRange;
     const [selectedOcc, setSelectedOcc] = useState<Occupancy | null>(null);
     const [quickAction, setQuickAction] = useState<{ date: Date } | null>(null);
+    const [isManualReservationOpen, setIsManualReservationOpen] = useState(false);
+    const [isBlockDatesOpen, setIsBlockDatesOpen] = useState(false);
+    const [selectedQuickActionDate, setSelectedQuickActionDate] = useState<Date | null>(null);
+
     const calendarRef = useRef<HTMLDivElement>(null);
     const todayStr = format(startOfToday(), 'yyyy-MM-dd');
 
@@ -46,7 +52,7 @@ export default function OccupancyCalendarPage() {
         weeks.push(dates.slice(i, i + 7));
     }
 
-    useEffect(() => {
+    const fetchOccupancyData = useCallback(() => {
         const anchor = startDate || startOfToday();
         const firstDay = startOfMonth(anchor);
         const lastDay = endOfMonth(anchor);
@@ -61,12 +67,21 @@ export default function OccupancyCalendarPage() {
             .catch(console.error);
     }, [startDate]);
 
+    useEffect(() => {
+        fetchOccupancyData();
+    }, [fetchOccupancyData]);
+
     const unitMap = new Map<string, string>();
     occupancies.forEach(o => {
         if (!unitMap.has(o.unitId)) {
             unitMap.set(o.unitId, o.unitName || o.unitId);
         }
     });
+
+    const uniqueUnits = Array.from(unitMap.entries()).map(([id, name]) => ({
+        id,
+        name
+    }));
 
     const handlePrevMonth = () => {
         const prev = addMonths(anchorDate, -1);
@@ -167,8 +182,11 @@ export default function OccupancyCalendarPage() {
 
     return (
         <div className="p-8 max-w-7xl mx-auto min-h-screen text-brand-main space-y-6">
-            <div className="flex justify-between items-center relative z-[100]">
-                <h1 className="text-3xl font-bold text-brand-main">Occupancy Dashboard</h1>
+            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 relative z-[100]">
+                <div>
+                    <h1 className="text-3xl font-bold text-brand-main">Occupancy Dashboard</h1>
+                    <p className="text-sm text-brand-muted mt-0.5">Manage occupancies, manual reservations, and maintenance blocks.</p>
+                </div>
                 <div className="flex bg-brand-bg p-1 rounded-lg border border-brand-accent shadow-sm">
                     <Link to="/admin/reservations" className="px-4 py-2 text-sm font-medium rounded-md text-brand-muted hover:bg-[#FFFFFF] hover:text-brand-main hover:shadow-sm transition-all">
                         List View
@@ -191,6 +209,26 @@ export default function OccupancyCalendarPage() {
                                 placeholderText="Select Month"
                             />
                         </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <button
+                            onClick={() => setIsManualReservationOpen(true)}
+                            className="px-4 py-2 text-sm font-bold text-white bg-brand-primary hover:bg-brand-primary-hover rounded-lg shadow-sm transition-all flex items-center gap-1.5 cursor-pointer"
+                        >
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                            </svg>
+                            Add Reservation
+                        </button>
+                        <button
+                            onClick={() => setIsBlockDatesOpen(true)}
+                            className="px-4 py-2 text-sm font-bold text-brand-main bg-white border border-brand-accent hover:bg-gray-50 rounded-lg shadow-sm transition-all flex items-center gap-1.5 cursor-pointer"
+                        >
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                            </svg>
+                            Block Dates
+                        </button>
                     </div>
                 </div>
             </div>
@@ -245,7 +283,7 @@ export default function OccupancyCalendarPage() {
                                         const hasOcc = occupancies.some(o => o.startDate <= dateStr && o.endDate >= dateStr);
                                         const isWeekend = dayIdx >= 5;
                                         return (
-                                            <div key={d.toISOString()} onClick={() => { if (!isPast && !hasOcc) setQuickAction({ date: d }); }} className={`h-full border-r border-brand-accent/5 last:border-r-0 ${isWeekend ? 'bg-gray-50/40' : ''} ${!isPast && !hasOcc ? 'cursor-pointer hover:bg-brand-accent/10 transition-colors' : ''}`} />
+                                            <div key={d.toISOString()} onClick={() => { if (!isPast && !hasOcc) { setQuickAction({ date: d }); setSelectedQuickActionDate(d); } }} className={`h-full border-r border-brand-accent/5 last:border-r-0 ${isWeekend ? 'bg-gray-50/40' : ''} ${!isPast && !hasOcc ? 'cursor-pointer hover:bg-brand-accent/10 transition-colors' : ''}`} />
                                         );
                                     })}
                                 </div>
@@ -264,14 +302,15 @@ export default function OccupancyCalendarPage() {
 
             {quickAction && (
                 <>
-                    <div className="fixed inset-0 bg-black/50 z-[9998] backdrop-blur-sm" onClick={() => setQuickAction(null)} />
-                    <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[9999] bg-white rounded-2xl shadow-2xl border border-brand-accent p-8 w-full max-w-sm space-y-6">
+                    <div className="fixed inset-0 bg-black/50 z-[9998] backdrop-blur-sm" onClick={() => { setQuickAction(null); setSelectedQuickActionDate(null); }} />
+                    <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[9999] bg-[#FFFFFF] rounded-2xl shadow-2xl border border-brand-accent p-8 w-full max-w-sm space-y-6">
                         <div className="text-center space-y-1">
                             <h3 className="text-lg font-bold text-brand-main">Quick Action</h3>
                             <p className="text-sm text-brand-muted">Date: <span className="font-bold text-brand-main">{format(quickAction.date, 'EEEE, d MMMM yyyy')}</span></p>
                         </div>
-                        <button onClick={() => setQuickAction(null)} className="w-full py-3 bg-brand-primary text-white font-bold rounded-lg hover:opacity-90 transition">New Booking</button>
-                        <button onClick={() => setQuickAction(null)} className="w-full py-3 border border-brand-accent rounded-lg text-brand-main font-bold hover:bg-gray-50 transition">Cancel</button>
+                        <button onClick={() => { setIsManualReservationOpen(true); setQuickAction(null); }} className="w-full py-3 bg-brand-primary text-white font-bold rounded-lg hover:opacity-90 transition cursor-pointer">New Booking</button>
+                        <button onClick={() => { setIsBlockDatesOpen(true); setQuickAction(null); }} className="w-full py-3 bg-[#FFFFFF] border border-brand-accent text-brand-main font-bold rounded-lg hover:bg-gray-50 transition cursor-pointer">Block Dates</button>
+                        <button onClick={() => { setQuickAction(null); setSelectedQuickActionDate(null); }} className="w-full py-3 border border-brand-accent rounded-lg text-brand-main font-bold hover:bg-gray-50 transition cursor-pointer">Cancel</button>
                     </div>
                 </>
             )}
@@ -382,6 +421,28 @@ export default function OccupancyCalendarPage() {
 
                     </div>
                 </>
+            )}
+
+            {isManualReservationOpen && (
+                <ManualReservationModal
+                    isOpen={isManualReservationOpen}
+                    onClose={() => { setIsManualReservationOpen(false); setSelectedQuickActionDate(null); }}
+                    onSuccess={fetchOccupancyData}
+                    units={uniqueUnits}
+                    initialStartDate={selectedQuickActionDate}
+                    occupancies={occupancies}
+                />
+            )}
+
+            {isBlockDatesOpen && (
+                <BlockDatesModal
+                    isOpen={isBlockDatesOpen}
+                    onClose={() => { setIsBlockDatesOpen(false); setSelectedQuickActionDate(null); }}
+                    onSuccess={fetchOccupancyData}
+                    units={uniqueUnits}
+                    initialStartDate={selectedQuickActionDate}
+                    occupancies={occupancies}
+                />
             )}
         </div>
     );

--- a/frontend/src/pages/OccupancyCalendarPage.tsx
+++ b/frontend/src/pages/OccupancyCalendarPage.tsx
@@ -99,7 +99,7 @@ export default function OccupancyCalendarPage() {
         const chunkEndStr = format(chunkDates[chunkDates.length - 1], 'yyyy-MM-dd');
 
         const overlapping = occupancies.filter(occ =>
-            occ.startDate <= chunkEndStr && occ.endDate >= chunkStartStr
+            occ.status !== 'CANCELLED' && occ.startDate <= chunkEndStr && occ.endDate >= chunkStartStr
         );
 
         overlapping.sort((a, b) => {
@@ -161,7 +161,7 @@ export default function OccupancyCalendarPage() {
                         key={occ.reservationId || occ.unitId + dateStr}
                         onClick={() => setSelectedOcc(occ)}
                         style={{ gridColumn: `${i + 1} / span ${span}` }}
-                        className={`h-8 ${roundedClass} ${bgColor} ${textColor} text-[10px] sm:text-xs font-bold flex items-center shadow-sm transition-colors truncate cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-brand-primary`}
+                        className={`h-8 ${roundedClass} ${bgColor} ${textColor} text-[10px] sm:text-xs font-bold flex items-center shadow-sm transition-colors truncate cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-brand-primary pointer-events-auto`}
                     >
                         <span className="truncate">{displayText}</span>
                     </button>
@@ -264,11 +264,18 @@ export default function OccupancyCalendarPage() {
                                     const dateStr = format(d, 'yyyy-MM-dd');
                                     const isCurrentMonth = format(d, 'MM') === format(anchorDate, 'MM');
                                     const isToday = dateStr === todayStr;
+                                    const isSelected = selectedQuickActionDate && dateStr === format(selectedQuickActionDate, 'yyyy-MM-dd');
+                                    const isHighlighted = isToday || isSelected;
                                     const isPast = isBefore(d, startOfToday()) && !isToday;
                                     const isWeekend = dayIdx >= 5;
                                     return (
-                                        <div key={d.toISOString()} className={`p-1.5 pr-2.5 text-right font-semibold text-xs border-r border-brand-accent/10 last:border-r-0 ${isWeekend ? 'bg-gray-50/60' : ''} ${isToday ? 'ring-1 ring-inset ring-brand-primary bg-brand-accent/15' : ''}`}>
-                                            <span className={`${isPast ? 'text-gray-300' : isCurrentMonth ? 'text-brand-main' : 'text-gray-300'} ${isToday ? 'font-black text-brand-primary' : ''}`}>
+                                        <div 
+                                            key={d.toISOString()} 
+                                            className={`p-1.5 pr-2.5 text-right font-semibold text-xs border-r border-brand-accent/10 last:border-r-0 ${isWeekend ? 'bg-gray-50/60' : ''} ${
+                                                isHighlighted ? 'bg-brand-accent/20 border-t-4 border-t-brand-primary border-x border-brand-accent/30 shadow-sm' : ''
+                                            }`}
+                                        >
+                                            <span className={`${isPast ? 'text-gray-300' : isCurrentMonth ? 'text-brand-main' : 'text-gray-300'} ${isHighlighted ? 'font-black text-brand-primary' : ''}`}>
                                                 {format(d, 'd')}
                                             </span>
                                         </div>
@@ -279,15 +286,27 @@ export default function OccupancyCalendarPage() {
                                 <div className="absolute inset-0 grid grid-cols-7">
                                     {weekDates.map((d, dayIdx) => {
                                         const dateStr = format(d, 'yyyy-MM-dd');
-                                        const isPast = isBefore(d, startOfToday());
-                                        const hasOcc = occupancies.some(o => o.startDate <= dateStr && o.endDate >= dateStr);
+                                        const isToday = dateStr === todayStr;
+                                        const isSelected = selectedQuickActionDate && dateStr === format(selectedQuickActionDate, 'yyyy-MM-dd');
+                                        const isHighlighted = isToday || isSelected;
                                         const isWeekend = dayIdx >= 5;
                                         return (
-                                            <div key={d.toISOString()} onClick={() => { if (!isPast && !hasOcc) { setQuickAction({ date: d }); setSelectedQuickActionDate(d); } }} className={`h-full border-r border-brand-accent/5 last:border-r-0 ${isWeekend ? 'bg-gray-50/40' : ''} ${!isPast && !hasOcc ? 'cursor-pointer hover:bg-brand-accent/10 transition-colors' : ''}`} />
+                                            <div
+                                                key={d.toISOString()}
+                                                onClick={() => {
+                                                    setQuickAction({ date: d });
+                                                    setSelectedQuickActionDate(d);
+                                                }}
+                                                className={`h-full border-r border-brand-accent/5 last:border-r-0 ${
+                                                    isWeekend ? "bg-gray-50/40" : ""
+                                                } ${
+                                                    isHighlighted ? "bg-brand-accent/10 border-x border-b border-brand-accent/30 shadow-inner" : ""
+                                                } cursor-pointer hover:bg-brand-accent/20 transition-colors`}
+                                            />
                                         );
                                     })}
                                 </div>
-                                <div className="relative z-[1] p-2 space-y-1">
+                                <div className="relative z-[1] p-2 space-y-1 pointer-events-none">
                                     {getLanesForChunk(weekDates).map((lane, laneIdx) => (
                                         <div key={laneIdx} className="grid grid-cols-7 gap-1">
                                             {renderLaneCellsForWeek(lane, weekDates)}

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileController.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileController.java
@@ -57,4 +57,16 @@ public class UserProfileController {
     final var user = userService.getUserById(userId);
     return ResponseEntity.ok(userMapper.toUserProfileDto(user));
   }
+
+  @GetMapping("/internal/by-email/{email}")
+  public ResponseEntity<UserProfileDto> getUserProfileByEmailInternal(
+      @PathVariable("email") String email,
+      @RequestHeader(value = "X-Internal-Token", required = false) String internalToken) {
+    if (internalToken == null || !internalToken.equals(expectedInternalToken)) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Access denied: Invalid internal token");
+    }
+    final var user = userService.getUserByEmail(email);
+    return ResponseEntity.ok(userMapper.toUserProfileDto(user));
+  }
 }

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileDto.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/dto/UserProfileDto.java
@@ -3,4 +3,9 @@ package io.github.kwatera_project.kwatera.auth_service.dto;
 import io.github.kwatera_project.kwatera.auth_service.model.Role;
 
 public record UserProfileDto(
-    String username, String firstName, String lastName, String email, Role role) {}
+    java.util.UUID id,
+    String username,
+    String firstName,
+    String lastName,
+    String email,
+    Role role) {}

--- a/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapper.java
+++ b/services/auth-service/src/main/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapper.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 public class UserMapper {
   public UserProfileDto toUserProfileDto(final User user) {
     return new UserProfileDto(
+        user.getId(),
         user.getUsername(),
         user.getFirstName(),
         user.getLastName(),

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/controller/UserProfileControllerTest.java
@@ -53,7 +53,7 @@ class UserProfileControllerTest {
     user.setLastName("Last");
     user.setRole(Role.GUEST);
 
-    UserProfileDto dto = new UserProfileDto(username, "First", "Last", email, Role.GUEST);
+    UserProfileDto dto = new UserProfileDto(id, username, "First", "Last", email, Role.GUEST);
 
     when(userService.getUserByEmail(email)).thenReturn(user);
     when(userMapper.toUserProfileDto(user)).thenReturn(dto);
@@ -91,7 +91,7 @@ class UserProfileControllerTest {
     updatedUser.setLastName("NewLast");
     updatedUser.setRole(Role.GUEST);
 
-    UserProfileDto dto = new UserProfileDto(username, "NewFirst", "NewLast", email, Role.GUEST);
+    UserProfileDto dto = new UserProfileDto(id, username, "NewFirst", "NewLast", email, Role.GUEST);
 
     when(userService.updateProfile(email, "NewFirst", "NewLast")).thenReturn(updatedUser);
     when(userMapper.toUserProfileDto(updatedUser)).thenReturn(dto);
@@ -147,7 +147,8 @@ class UserProfileControllerTest {
     user.setLastName("Last");
     user.setRole(Role.GUEST);
 
-    UserProfileDto dto = new UserProfileDto("test", "First", "Last", "test@mail.com", Role.GUEST);
+    UserProfileDto dto =
+        new UserProfileDto(id, "test", "First", "Last", "test@mail.com", Role.GUEST);
 
     when(userService.getUserById(id)).thenReturn(user);
     when(userMapper.toUserProfileDto(user)).thenReturn(dto);
@@ -174,6 +175,47 @@ class UserProfileControllerTest {
     java.util.UUID id = java.util.UUID.randomUUID();
     mockMvc
         .perform(get("/api/auth/users/internal/" + id).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldReturnUserProfileByEmailInternal_withToken() throws Exception {
+    String email = "test@mail.com";
+    java.util.UUID id = java.util.UUID.randomUUID();
+    User user = new User();
+    user.setId(id);
+    user.setUsername("test");
+    user.setEmail(email);
+    user.setFirstName("First");
+    user.setLastName("Last");
+    user.setRole(Role.GUEST);
+
+    UserProfileDto dto = new UserProfileDto(id, "test", "First", "Last", email, Role.GUEST);
+
+    when(userService.getUserByEmail(email)).thenReturn(user);
+    when(userMapper.toUserProfileDto(user)).thenReturn(dto);
+
+    mockMvc
+        .perform(
+            get("/api/auth/users/internal/by-email/" + email)
+                .header("X-Internal-Token", "kwatera-internal-secret-token")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value(id.toString()))
+        .andExpect(jsonPath("$.username").value("test"))
+        .andExpect(jsonPath("$.email").value(email));
+
+    verify(userService).getUserByEmail(email);
+    verify(userMapper).toUserProfileDto(user);
+  }
+
+  @Test
+  void shouldRejectUserProfileByEmailInternal_withoutToken() throws Exception {
+    String email = "test@mail.com";
+    mockMvc
+        .perform(
+            get("/api/auth/users/internal/by-email/" + email).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isForbidden());
   }
 }

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/dto/DtoTest.java
@@ -9,9 +9,11 @@ class DtoTest {
 
   @Test
   void testUserProfileDto() {
+    java.util.UUID id = java.util.UUID.randomUUID();
     UserProfileDto dto =
-        new UserProfileDto("username", "John", "Doe", "john@example.com", Role.GUEST);
+        new UserProfileDto(id, "username", "John", "Doe", "john@example.com", Role.GUEST);
 
+    assertThat(dto.id()).isEqualTo(id);
     assertThat(dto.username()).isEqualTo("username");
     assertThat(dto.firstName()).isEqualTo("John");
     assertThat(dto.lastName()).isEqualTo("Doe");

--- a/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapperTest.java
+++ b/services/auth-service/src/test/java/io/github/kwatera_project/kwatera/auth_service/mapper/UserMapperTest.java
@@ -26,6 +26,7 @@ class UserMapperTest {
     UserProfileDto dto = userMapper.toUserProfileDto(user);
 
     assertThat(dto).isNotNull();
+    assertThat(dto.id()).isEqualTo(id);
     assertThat(dto.username()).isEqualTo("john");
     assertThat(dto.firstName()).isEqualTo("John");
     assertThat(dto.lastName()).isEqualTo("Doe");

--- a/services/db-migrations/src/main/resources/db/migration/V21__allow_single_day_blocks.sql
+++ b/services/db-migrations/src/main/resources/db/migration/V21__allow_single_day_blocks.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reservations DROP CONSTRAINT check_dates;
+ALTER TABLE reservations ADD CONSTRAINT check_dates CHECK (end_date >= start_date);

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/SecurityConfig.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 auth.requestMatchers(HttpMethod.OPTIONS, "/**")
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/reservations")
-                    .hasAuthority("ROLE_GUEST")
+                    .hasAnyAuthority("ROLE_GUEST", "ROLE_OWNER", "ROLE_ADMIN")
                     .requestMatchers("/api/v1/admin/reservations", "/api/v1/admin/reservations/**")
                     .hasAnyAuthority("ROLE_ADMIN", "ROLE_OWNER")
                     .requestMatchers("/api/v1/admin/occupancy", "/api/v1/admin/occupancy/**")

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationController.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationController.java
@@ -35,7 +35,10 @@ public class ReservationController {
       HttpServletRequest httpServletRequest) {
 
     UUID guestId = validateAndGetUserId(authentication);
-    String guestEmail = authentication.getName();
+    String guestEmail =
+        (request.getGuestEmail() != null && !request.getGuestEmail().isBlank())
+            ? request.getGuestEmail()
+            : authentication.getName();
     String token = httpServletRequest.getHeader("Authorization");
 
     return reservationService.createReservation(guestId, guestEmail, request, token);

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationController.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationController.java
@@ -34,14 +34,35 @@ public class ReservationController {
       Authentication authentication,
       HttpServletRequest httpServletRequest) {
 
-    UUID guestId = validateAndGetUserId(authentication);
-    String guestEmail =
-        (request.getGuestEmail() != null && !request.getGuestEmail().isBlank())
-            ? request.getGuestEmail()
-            : authentication.getName();
+    UUID actorId = validateAndGetUserId(authentication);
     String token = httpServletRequest.getHeader("Authorization");
 
-    return reservationService.createReservation(guestId, guestEmail, request, token);
+    boolean isAdmin =
+        authentication.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+    boolean isOwner =
+        authentication.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals("ROLE_OWNER"));
+    boolean isGuest =
+        authentication.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals("ROLE_GUEST"));
+
+    if (isGuest && !isAdmin && !isOwner) {
+      if (request.getStatus() != null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Guests cannot specify reservation status");
+      }
+      if (request.getGuestEmail() != null
+          && !request.getGuestEmail().isBlank()
+          && !request.getGuestEmail().equals(authentication.getName())) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Guests cannot specify a different guest email");
+      }
+      String guestEmail = authentication.getName();
+      return reservationService.createReservation(actorId, guestEmail, request, token);
+    }
+
+    return reservationService.createReservation(actorId, isAdmin, isOwner, request, token);
   }
 
   @GetMapping("/my")

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/dto/CreateReservationRequest.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/dto/CreateReservationRequest.java
@@ -21,4 +21,8 @@ public class CreateReservationRequest {
       regexp = "^(?i)(PLN|EUR|USD)$",
       message = "Unsupported currency")
   private String currency;
+
+  private String guestEmail;
+
+  private io.github.kwatera_project.kwatera.reservation_service.model.ReservationStatus status;
 }

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/model/Reservation.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/model/Reservation.java
@@ -2,6 +2,7 @@ package io.github.kwatera_project.kwatera.reservation_service.model;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -56,7 +57,7 @@ public class Reservation {
   private BigDecimal pricePerNightSnapshot;
 
   @Column(name = "total_price", nullable = false)
-  @Positive
+  @PositiveOrZero
   private BigDecimal totalPrice;
 
   @Column(name = "payment_currency", nullable = false)

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/model/ReservationStatus.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/model/ReservationStatus.java
@@ -4,5 +4,6 @@ public enum ReservationStatus {
   PENDING,
   CONFIRMED,
   CANCELLED,
-  COMPLETED
+  COMPLETED,
+  BLOCKED
 }

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/EmailNotificationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/EmailNotificationService.java
@@ -250,6 +250,7 @@ public class EmailNotificationService {
       case CONFIRMED -> "background-color: #D1FAE5; color: #065F46;";
       case CANCELLED -> "background-color: #FEE2E2; color: #991B1B;";
       case COMPLETED -> "background-color: #F9F5F5; color: #42211D; border: 1px solid #DACDCA;";
+      case BLOCKED -> "background-color: #F3F4F6; color: #374151;";
     };
   }
 

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -45,7 +45,7 @@ public class ReservationService {
     if (from.isBefore(today)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Date is in the past");
     }
-    if (!from.isBefore(to)) {
+    if (from.isAfter(to)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid date range");
     }
     if (unitId == null) {
@@ -57,7 +57,16 @@ public class ReservationService {
           || r.getStatus() == ReservationStatus.COMPLETED) {
         continue;
       }
-      if (from.isBefore(r.getEndDate()) && to.isAfter(r.getStartDate())) {
+      LocalDate min1 = from;
+      LocalDate max1 = from.isBefore(to) ? to.minusDays(1) : from;
+
+      LocalDate min2 = r.getStartDate();
+      LocalDate max2 =
+          r.getStartDate().isBefore(r.getEndDate())
+              ? r.getEndDate().minusDays(1)
+              : r.getStartDate();
+
+      if (!min1.isAfter(max2) && !max1.isBefore(min2)) {
         return new AvailabilityDto(false, "Unit is not available in selected dates");
       }
     }
@@ -209,7 +218,11 @@ public class ReservationService {
     reservation.setUnitId(request.getUnitId());
     reservation.setStartDate(request.getStartDate());
     reservation.setEndDate(request.getEndDate());
-    reservation.setStatus(ReservationStatus.PENDING);
+    if (request.getStatus() != null) {
+      reservation.setStatus(request.getStatus());
+    } else {
+      reservation.setStatus(ReservationStatus.PENDING);
+    }
 
     BigDecimal pricePerNight = fetchUnitPrice(request.getUnitId(), token);
     long days =
@@ -248,11 +261,13 @@ public class ReservationService {
     reservation.setPaymentExchangeRate(paymentExchangeRate);
 
     Reservation saved = reservationRepository.save(reservation);
-    emailNotificationService.sendReservationCreated(saved, saved.getGuestEmail());
-    try {
-      emailNotificationService.sendOwnerReservationCreated(saved);
-    } catch (Exception e) {
-      log.warn("Failed to send owner notification for reservation creation", e);
+    if (saved.getStatus() != ReservationStatus.BLOCKED) {
+      emailNotificationService.sendReservationCreated(saved, saved.getGuestEmail());
+      try {
+        emailNotificationService.sendOwnerReservationCreated(saved);
+      } catch (Exception e) {
+        log.warn("Failed to send owner notification for reservation creation", e);
+      }
     }
     return saved;
   }

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -221,6 +221,13 @@ public class ReservationService {
     }
   }
 
+  private long calculateBillableNights(ReservationStatus status, LocalDate startDate, LocalDate endDate) {
+    if (status == ReservationStatus.BLOCKED) {
+      return 0;
+    }
+    return java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate);
+  }
+
   @Transactional
   public Reservation createReservation(
       UUID userId, CreateReservationRequest request, String token) {
@@ -297,6 +304,12 @@ public class ReservationService {
           HttpStatus.CONFLICT, "The selected dates are no longer available");
     }
 
+    long billableNights = calculateBillableNights(status, request.getStartDate(), request.getEndDate());
+    if (status != ReservationStatus.BLOCKED && billableNights <= 0) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Reservation must include at least one billable night");
+    }
+
     Reservation reservation = new Reservation();
     reservation.setUserId(finalUserId);
     reservation.setGuestEmail(finalGuestEmail);
@@ -306,9 +319,7 @@ public class ReservationService {
     reservation.setStatus(status);
 
     BigDecimal pricePerNight = fetchUnitPrice(request.getUnitId(), token);
-    long days =
-        java.time.temporal.ChronoUnit.DAYS.between(request.getStartDate(), request.getEndDate());
-    BigDecimal totalPrice = pricePerNight.multiply(BigDecimal.valueOf(days));
+    BigDecimal totalPrice = pricePerNight.multiply(BigDecimal.valueOf(billableNights));
 
     reservation.setPricePerNightSnapshot(pricePerNight);
     reservation.setTotalPrice(totalPrice);

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -193,14 +193,14 @@ public class ReservationService {
   }
 
   private UUID fetchUserIdByEmail(String email) {
-    String url = authServiceUrl + "/internal/by-email/" + email;
+    String url = authServiceUrl + "/internal/by-email/{email}";
     HttpHeaders headers = new HttpHeaders();
     headers.set("X-Internal-Token", internalToken);
     HttpEntity<Void> entity = new HttpEntity<>(headers);
 
     try {
       ResponseEntity<java.util.Map> response =
-          restTemplate.exchange(url, HttpMethod.GET, entity, java.util.Map.class);
+          restTemplate.exchange(url, HttpMethod.GET, entity, java.util.Map.class, email);
       if (response.getBody() == null || response.getBody().get("id") == null) {
         throw new ResponseStatusException(
             HttpStatus.BAD_REQUEST, "Guest with the specified email does not exist");

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,12 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
+
+  @Value("${services.auth.url:http://auth-service/api/auth/users}")
+  private String authServiceUrl = "http://auth-service/api/auth/users";
+
+  @Value("${kwatera.security.internal-token:kwatera-internal-secret-token}")
+  private String internalToken = "kwatera-internal-secret-token";
 
   private static final Logger log = LoggerFactory.getLogger(ReservationService.class);
   private static final String RESERVATION_NOT_FOUND = "Reservation not found";
@@ -185,26 +192,104 @@ public class ReservationService {
     }
   }
 
+  private UUID fetchUserIdByEmail(String email) {
+    String url = authServiceUrl + "/internal/by-email/" + email;
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("X-Internal-Token", internalToken);
+    HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+    try {
+      ResponseEntity<java.util.Map> response =
+          restTemplate.exchange(url, HttpMethod.GET, entity, java.util.Map.class);
+      if (response.getBody() == null || response.getBody().get("id") == null) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Guest with the specified email does not exist");
+      }
+      return UUID.fromString(response.getBody().get("id").toString());
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+        throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Guest with the specified email does not exist");
+      }
+      throw new ResponseStatusException(
+          HttpStatus.BAD_GATEWAY, "Cannot fetch guest details: " + e.getMessage());
+    } catch (ResponseStatusException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_GATEWAY, "Cannot fetch guest details: " + e.getMessage());
+    }
+  }
+
   @Transactional
   public Reservation createReservation(
       UUID userId, CreateReservationRequest request, String token) {
-    return createReservationInternal(userId, null, request, token);
+    return createReservation(userId, false, false, request, token);
   }
 
   @Transactional
   public Reservation createReservation(
       UUID userId, String guestEmail, CreateReservationRequest request, String token) {
-    return createReservationInternal(userId, guestEmail, request, token);
+    if (request != null && (request.getGuestEmail() == null || request.getGuestEmail().isBlank())) {
+      request.setGuestEmail(guestEmail);
+    }
+    return createReservation(userId, false, false, request, token);
   }
 
-  private Reservation createReservationInternal(
-      UUID userId, String guestEmail, CreateReservationRequest request, String token) {
-    if (userId == null) {
+  @Transactional
+  public Reservation createReservation(
+      UUID actorId,
+      boolean isAdmin,
+      boolean isOwner,
+      CreateReservationRequest request,
+      String token) {
+    if (actorId == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User id is required");
     }
     if (request == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Reservation request is required");
     }
+
+    if (isOwner && !isAdmin) {
+      if (!ownerHasAccessToUnit(actorId, request.getUnitId())) {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not own this unit");
+      }
+    }
+
+    boolean isGuest = !isAdmin && !isOwner;
+
+    ReservationStatus status;
+    UUID finalUserId;
+    String finalGuestEmail;
+
+    if (request.getStatus() != null) {
+      status = request.getStatus();
+    } else {
+      if (isGuest) {
+        status = ReservationStatus.PENDING;
+      } else if (request.getGuestEmail() != null && !request.getGuestEmail().isBlank()) {
+        status = ReservationStatus.CONFIRMED;
+      } else {
+        status = ReservationStatus.BLOCKED;
+      }
+    }
+
+    if (status == ReservationStatus.BLOCKED) {
+      finalUserId = actorId;
+      finalGuestEmail = request.getGuestEmail();
+    } else {
+      if (!isGuest && (request.getGuestEmail() == null || request.getGuestEmail().isBlank())) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Guest email is required");
+      }
+      if (isGuest) {
+        finalUserId = actorId;
+        finalGuestEmail = request.getGuestEmail();
+      } else {
+        finalUserId = fetchUserIdByEmail(request.getGuestEmail());
+        finalGuestEmail = request.getGuestEmail();
+      }
+    }
+
     AvailabilityDto availability =
         checkAvailability(request.getUnitId(), request.getStartDate(), request.getEndDate());
     if (!availability.isAvailable()) {
@@ -213,16 +298,12 @@ public class ReservationService {
     }
 
     Reservation reservation = new Reservation();
-    reservation.setUserId(userId);
-    reservation.setGuestEmail(guestEmail);
+    reservation.setUserId(finalUserId);
+    reservation.setGuestEmail(finalGuestEmail);
     reservation.setUnitId(request.getUnitId());
     reservation.setStartDate(request.getStartDate());
     reservation.setEndDate(request.getEndDate());
-    if (request.getStatus() != null) {
-      reservation.setStatus(request.getStatus());
-    } else {
-      reservation.setStatus(ReservationStatus.PENDING);
-    }
+    reservation.setStatus(status);
 
     BigDecimal pricePerNight = fetchUnitPrice(request.getUnitId(), token);
     long days =

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -221,7 +221,8 @@ public class ReservationService {
     }
   }
 
-  private long calculateBillableNights(ReservationStatus status, LocalDate startDate, LocalDate endDate) {
+  private long calculateBillableNights(
+      ReservationStatus status, LocalDate startDate, LocalDate endDate) {
     if (status == ReservationStatus.BLOCKED) {
       return 0;
     }
@@ -304,7 +305,8 @@ public class ReservationService {
           HttpStatus.CONFLICT, "The selected dates are no longer available");
     }
 
-    long billableNights = calculateBillableNights(status, request.getStartDate(), request.getEndDate());
+    long billableNights =
+        calculateBillableNights(status, request.getStartDate(), request.getEndDate());
     if (status != ReservationStatus.BLOCKED && billableNights <= 0) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST, "Reservation must include at least one billable night");

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationStatusValidator.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationStatusValidator.java
@@ -18,6 +18,7 @@ public class ReservationStatusValidator {
           case CONFIRMED ->
               newStatus == ReservationStatus.COMPLETED || newStatus == ReservationStatus.CANCELLED;
           case COMPLETED, CANCELLED -> false;
+          case BLOCKED -> newStatus == ReservationStatus.CANCELLED;
         };
 
     if (!isValid)

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationControllerTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationControllerTest.java
@@ -87,10 +87,7 @@ class ReservationControllerTest {
             + "\"guestEmail\":\"manual.guest@example.com\"}";
 
     when(reservationService.createReservation(
-            eq(userId),
-            eq("manual.guest@example.com"),
-            any(CreateReservationRequest.class),
-            anyString()))
+            eq(userId), eq(false), eq(true), any(CreateReservationRequest.class), anyString()))
         .thenReturn(new Reservation());
 
     mockMvc
@@ -105,7 +102,8 @@ class ReservationControllerTest {
     verify(reservationService)
         .createReservation(
             eq(userId),
-            eq("manual.guest@example.com"),
+            eq(false),
+            eq(true),
             any(CreateReservationRequest.class),
             eq("Bearer mock-token"));
   }
@@ -120,7 +118,7 @@ class ReservationControllerTest {
             + "\"guestEmail\":\"   \"}";
 
     when(reservationService.createReservation(
-            eq(userId), eq("user@test.com"), any(CreateReservationRequest.class), anyString()))
+            eq(userId), eq(false), eq(true), any(CreateReservationRequest.class), anyString()))
         .thenReturn(new Reservation());
 
     mockMvc
@@ -135,7 +133,8 @@ class ReservationControllerTest {
     verify(reservationService)
         .createReservation(
             eq(userId),
-            eq("user@test.com"),
+            eq(false),
+            eq(true),
             any(CreateReservationRequest.class),
             eq("Bearer mock-token"));
   }
@@ -364,5 +363,41 @@ class ReservationControllerTest {
     mockMvc
         .perform(get("/api/v1/reservations/internal/" + reservationId))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldFailCreateReservation_whenGuestAttemptsToSetStatus() throws Exception {
+    UUID userId = UUID.randomUUID();
+    String json =
+        "{\"unitId\":\""
+            + UUID.randomUUID()
+            + "\", \"startDate\":\"2026-10-10\", \"endDate\":\"2026-10-15\", \"status\":\"BLOCKED\"}";
+
+    mockMvc
+        .perform(
+            post("/api/v1/reservations")
+                .header("Authorization", "Bearer mock-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .with(authentication(buildAuth(userId, "ROLE_GUEST"))))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldFailCreateReservation_whenGuestAttemptsToSetDifferentEmail() throws Exception {
+    UUID userId = UUID.randomUUID();
+    String json =
+        "{\"unitId\":\""
+            + UUID.randomUUID()
+            + "\", \"startDate\":\"2026-10-10\", \"endDate\":\"2026-10-15\", \"guestEmail\":\"hacker@test.com\"}";
+
+    mockMvc
+        .perform(
+            post("/api/v1/reservations")
+                .header("Authorization", "Bearer mock-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .with(authentication(buildAuth(userId, "ROLE_GUEST"))))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationControllerTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/ReservationControllerTest.java
@@ -78,6 +78,69 @@ class ReservationControllerTest {
   }
 
   @Test
+  void shouldCreateReservationWithGuestEmailFromRequest_whenProvided() throws Exception {
+    UUID userId = UUID.randomUUID();
+    String json =
+        "{\"unitId\":\""
+            + UUID.randomUUID()
+            + "\", \"startDate\":\"2026-10-10\", \"endDate\":\"2026-10-15\", "
+            + "\"guestEmail\":\"manual.guest@example.com\"}";
+
+    when(reservationService.createReservation(
+            eq(userId),
+            eq("manual.guest@example.com"),
+            any(CreateReservationRequest.class),
+            anyString()))
+        .thenReturn(new Reservation());
+
+    mockMvc
+        .perform(
+            post("/api/v1/reservations")
+                .header("Authorization", "Bearer mock-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .with(authentication(buildAuth(userId, "ROLE_OWNER"))))
+        .andExpect(status().isCreated());
+
+    verify(reservationService)
+        .createReservation(
+            eq(userId),
+            eq("manual.guest@example.com"),
+            any(CreateReservationRequest.class),
+            eq("Bearer mock-token"));
+  }
+
+  @Test
+  void shouldFallbackToAuthenticatedEmail_whenGuestEmailIsBlank() throws Exception {
+    UUID userId = UUID.randomUUID();
+    String json =
+        "{\"unitId\":\""
+            + UUID.randomUUID()
+            + "\", \"startDate\":\"2026-10-10\", \"endDate\":\"2026-10-15\", "
+            + "\"guestEmail\":\"   \"}";
+
+    when(reservationService.createReservation(
+            eq(userId), eq("user@test.com"), any(CreateReservationRequest.class), anyString()))
+        .thenReturn(new Reservation());
+
+    mockMvc
+        .perform(
+            post("/api/v1/reservations")
+                .header("Authorization", "Bearer mock-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .with(authentication(buildAuth(userId, "ROLE_OWNER"))))
+        .andExpect(status().isCreated());
+
+    verify(reservationService)
+        .createReservation(
+            eq(userId),
+            eq("user@test.com"),
+            any(CreateReservationRequest.class),
+            eq("Bearer mock-token"));
+  }
+
+  @Test
   void shouldFail_whenTokenIsMissing() throws Exception {
     mockMvc
         .perform(post("/api/v1/reservations").contentType(MediaType.APPLICATION_JSON).content("{}"))

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/EmailNotificationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/EmailNotificationServiceTest.java
@@ -91,6 +91,24 @@ class EmailNotificationServiceTest {
   }
 
   @Test
+  void shouldUseBlockedStatusStyleInGuestNotification() {
+    Reservation reservation = reservation();
+    reservation.setStatus(ReservationStatus.BLOCKED);
+
+    service.sendReservationCreated(reservation, "actual.guest@example.com");
+
+    ArgumentCaptor<Context> contextCaptor = ArgumentCaptor.forClass(Context.class);
+    verify(templateEngine)
+        .process(
+            org.mockito.ArgumentMatchers.eq("reservation-confirmation"), contextCaptor.capture());
+
+    Context context = contextCaptor.getValue();
+
+    assertEquals("BLOCKED", context.getVariable("statusLabel"));
+    assertEquals("background-color: #F3F4F6; color: #374151;", context.getVariable("statusStyle"));
+  }
+
+  @Test
   void shouldSendReservationStatusChangedEmail() throws Exception {
     Reservation reservation = reservation();
 

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -2044,10 +2044,11 @@ class ReservationServiceTest {
     java.util.Map<String, Object> guestMap = new java.util.HashMap<>();
     guestMap.put("id", guestId.toString());
     when(restTemplate.exchange(
-            contains("/internal/by-email/guest@test.com"),
+            anyString(),
             eq(HttpMethod.GET),
             any(HttpEntity.class),
-            eq(java.util.Map.class)))
+            eq(java.util.Map.class),
+            eq("guest@test.com")))
         .thenReturn(ResponseEntity.ok(guestMap));
 
     when(repository.findByUnitId(unitId)).thenReturn(List.of());
@@ -2093,10 +2094,11 @@ class ReservationServiceTest {
         .thenReturn(new UUID[] {unitId});
 
     when(restTemplate.exchange(
-            contains("/internal/by-email/nonexistent@test.com"),
+            anyString(),
             eq(HttpMethod.GET),
             any(HttpEntity.class),
-            eq(java.util.Map.class)))
+            eq(java.util.Map.class),
+            eq("nonexistent@test.com")))
         .thenThrow(
             new org.springframework.web.client.HttpClientErrorException(HttpStatus.NOT_FOUND));
 

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -1939,4 +1939,214 @@ class ReservationServiceTest {
 
     assertDoesNotThrow(service::notifyUpcomingReservations);
   }
+
+  @Test
+  void shouldCreateBlockedReservation_whenOwnerOrAdminBlocksDates() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    EmailNotificationService emailService = mock(EmailNotificationService.class);
+    ReservationService service =
+        new ReservationService(
+            repository,
+            restTemplate,
+            mock(NbpExchangeRateClient.class),
+            emailService,
+            new BusinessDateProvider("Europe/Warsaw"));
+
+    UUID actorId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    String mockToken = "some-jwt-token";
+    LocalDate start = LocalDate.now().plusDays(10);
+    LocalDate end = LocalDate.now().plusDays(15);
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(start);
+    request.setEndDate(end);
+
+    UnitDto mockUnit = new UnitDto();
+    mockUnit.setPricePerNight(new BigDecimal("200.00"));
+
+    // Mock unit ownership check
+    when(restTemplate.getForObject(
+            eq("http://property-service/api/properties/units/ids/{ownerId}"),
+            eq(UUID[].class),
+            eq(actorId)))
+        .thenReturn(new UUID[] {unitId});
+
+    when(restTemplate.exchange(
+            anyString(),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(UnitDto.class),
+            any(UUID.class)))
+        .thenReturn(ResponseEntity.ok(mockUnit));
+
+    when(repository.findByUnitId(unitId)).thenReturn(List.of());
+    when(repository.save(any(Reservation.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    Reservation created = service.createReservation(actorId, false, true, request, mockToken);
+
+    assertNotNull(created);
+    assertEquals(actorId, created.getUserId());
+    assertNull(created.getGuestEmail());
+    assertEquals(ReservationStatus.BLOCKED, created.getStatus());
+    verify(emailService, never()).sendReservationCreated(any(), any());
+  }
+
+  @Test
+  void shouldCreateReservation_whenOwnerCreatesManualReservationForGuest() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    EmailNotificationService emailService = mock(EmailNotificationService.class);
+    ReservationService service =
+        new ReservationService(
+            repository,
+            restTemplate,
+            mock(NbpExchangeRateClient.class),
+            emailService,
+            new BusinessDateProvider("Europe/Warsaw"));
+
+    UUID ownerId = UUID.randomUUID();
+    UUID guestId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    String mockToken = "some-jwt-token";
+    LocalDate start = LocalDate.now().plusDays(10);
+    LocalDate end = LocalDate.now().plusDays(15);
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(start);
+    request.setEndDate(end);
+    request.setGuestEmail("guest@test.com");
+
+    UnitDto mockUnit = new UnitDto();
+    mockUnit.setPricePerNight(new BigDecimal("200.00"));
+
+    // Mock unit ownership check
+    when(restTemplate.getForObject(
+            eq("http://property-service/api/properties/units/ids/{ownerId}"),
+            eq(UUID[].class),
+            eq(ownerId)))
+        .thenReturn(new UUID[] {unitId});
+
+    // Mock unit price check
+    when(restTemplate.exchange(
+            contains("/units/"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(UnitDto.class),
+            eq(unitId)))
+        .thenReturn(ResponseEntity.ok(mockUnit));
+
+    // Mock guest ID lookup
+    java.util.Map<String, Object> guestMap = new java.util.HashMap<>();
+    guestMap.put("id", guestId.toString());
+    when(restTemplate.exchange(
+            contains("/internal/by-email/guest@test.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(java.util.Map.class)))
+        .thenReturn(ResponseEntity.ok(guestMap));
+
+    when(repository.findByUnitId(unitId)).thenReturn(List.of());
+    when(repository.save(any(Reservation.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    Reservation created = service.createReservation(ownerId, false, true, request, mockToken);
+
+    assertNotNull(created);
+    assertEquals(guestId, created.getUserId());
+    assertEquals("guest@test.com", created.getGuestEmail());
+    assertEquals(ReservationStatus.CONFIRMED, created.getStatus());
+    verify(emailService).sendReservationCreated(created, "guest@test.com");
+  }
+
+  @Test
+  void shouldFailCreateReservation_whenOwnerCreatesManualReservationAndGuestNotFound() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ReservationService service =
+        new ReservationService(
+            repository,
+            restTemplate,
+            mock(NbpExchangeRateClient.class),
+            mock(EmailNotificationService.class),
+            new BusinessDateProvider("Europe/Warsaw"));
+
+    UUID ownerId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    String mockToken = "some-jwt-token";
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(LocalDate.now().plusDays(10));
+    request.setEndDate(LocalDate.now().plusDays(15));
+    request.setGuestEmail("nonexistent@test.com");
+
+    // Mock unit ownership check
+    when(restTemplate.getForObject(
+            eq("http://property-service/api/properties/units/ids/{ownerId}"),
+            eq(UUID[].class),
+            eq(ownerId)))
+        .thenReturn(new UUID[] {unitId});
+
+    when(restTemplate.exchange(
+            contains("/internal/by-email/nonexistent@test.com"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(java.util.Map.class)))
+        .thenThrow(
+            new org.springframework.web.client.HttpClientErrorException(HttpStatus.NOT_FOUND));
+
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> {
+              service.createReservation(ownerId, false, true, request, mockToken);
+            });
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    assertTrue(exception.getReason().contains("Guest with the specified email does not exist"));
+  }
+
+  @Test
+  void shouldFailCreateReservation_whenOwnerReservesUnitTheyDoNotOwn() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ReservationService service =
+        new ReservationService(
+            repository,
+            restTemplate,
+            mock(NbpExchangeRateClient.class),
+            mock(EmailNotificationService.class),
+            new BusinessDateProvider("Europe/Warsaw"));
+
+    UUID ownerId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    String mockToken = "some-jwt-token";
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(LocalDate.now().plusDays(10));
+    request.setEndDate(LocalDate.now().plusDays(15));
+
+    // Mock unit ownership check
+    when(restTemplate.getForObject(
+            eq("http://property-service/api/properties/units/ids/{ownerId}"),
+            eq(UUID[].class),
+            eq(ownerId)))
+        .thenReturn(new UUID[] {UUID.randomUUID()}); // return different unit ID
+
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> {
+              service.createReservation(ownerId, false, true, request, mockToken);
+            });
+
+    assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+    assertTrue(exception.getReason().contains("You do not own this unit"));
+  }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -2240,6 +2240,7 @@ class ReservationServiceTest {
             () -> service.createReservation(userId, request, mockToken));
 
     assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
-    assertTrue(exception.getReason().contains("Reservation must include at least one billable night"));
+    assertTrue(
+        exception.getReason().contains("Reservation must include at least one billable night"));
   }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -189,6 +189,29 @@ class ReservationServiceTest {
   }
 
   @Test
+  void shouldReturnUnavailableWhenSingleDayBlockOverlapsRequestedSingleDay() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    ReservationService service =
+        reservationService(repository, mock(RestTemplate.class), mock(NbpExchangeRateClient.class));
+
+    UUID unitId = UUID.randomUUID();
+    LocalDate blockedDay = LocalDate.now().plusDays(10);
+
+    Reservation block = new Reservation();
+    block.setUnitId(unitId);
+    block.setStartDate(blockedDay);
+    block.setEndDate(blockedDay);
+    block.setStatus(ReservationStatus.BLOCKED);
+
+    when(repository.findByUnitId(unitId)).thenReturn(List.of(block));
+
+    AvailabilityDto result = service.checkAvailability(unitId, blockedDay, blockedDay);
+
+    assertFalse(result.isAvailable());
+    assertEquals("Unit is not available in selected dates", result.getMessage());
+  }
+
+  @Test
   void shouldCreateReservationSuccessfullyWhenDatesAreAvailable() {
     ReservationRepository repository = mock(ReservationRepository.class);
     RestTemplate restTemplate = mock(RestTemplate.class);
@@ -1254,6 +1277,56 @@ class ReservationServiceTest {
     assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
     assertEquals("Unsupported currency", ex.getReason());
     verify(repository, never()).save(any());
+  }
+
+  @Test
+  void shouldCreateBlockedReservationWithoutSendingNotifications() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    EmailNotificationService emailService = mock(EmailNotificationService.class);
+
+    ReservationService service =
+        new ReservationService(
+            repository,
+            restTemplate,
+            mock(NbpExchangeRateClient.class),
+            emailService,
+            new BusinessDateProvider("Europe/Warsaw"));
+
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    LocalDate blockedDay = LocalDate.now().plusDays(10);
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(blockedDay);
+    request.setEndDate(blockedDay);
+    request.setCurrency("PLN");
+    request.setStatus(ReservationStatus.BLOCKED);
+
+    UnitDto mockUnit = new UnitDto();
+    mockUnit.setPricePerNight(new BigDecimal("200.00"));
+
+    when(repository.findByUnitId(unitId)).thenReturn(List.of());
+    when(restTemplate.exchange(
+            anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(UnitDto.class), eq(unitId)))
+        .thenReturn(ResponseEntity.ok(mockUnit));
+    when(repository.save(any(Reservation.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    Reservation created =
+        service.createReservation(userId, "manual.guest@example.com", request, "Bearer mock-token");
+
+    assertEquals(userId, created.getUserId());
+    assertEquals("manual.guest@example.com", created.getGuestEmail());
+    assertEquals(unitId, created.getUnitId());
+    assertEquals(blockedDay, created.getStartDate());
+    assertEquals(blockedDay, created.getEndDate());
+    assertEquals(ReservationStatus.BLOCKED, created.getStatus());
+    assertEquals(0, BigDecimal.ZERO.compareTo(created.getTotalPrice()));
+
+    verify(repository).save(any(Reservation.class));
+    verifyNoInteractions(emailService);
   }
 
   @Test

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -135,7 +135,7 @@ class ReservationServiceTest {
 
     UUID id = UUID.randomUUID();
     LocalDate from = LocalDate.now().plusDays(5);
-    LocalDate to = from;
+    LocalDate to = from.minusDays(1);
 
     assertThrows(ResponseStatusException.class, () -> service.checkAvailability(id, from, to));
   }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -2151,4 +2151,95 @@ class ReservationServiceTest {
     assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
     assertTrue(exception.getReason().contains("You do not own this unit"));
   }
+
+  @Test
+  void shouldCreateSingleDayBlockedReservation_whenOwnerBlocksDates() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    EmailNotificationService emailService = mock(EmailNotificationService.class);
+    ReservationService service =
+        new ReservationService(
+            repository,
+            restTemplate,
+            mock(NbpExchangeRateClient.class),
+            emailService,
+            new BusinessDateProvider("Europe/Warsaw"));
+
+    UUID actorId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    String mockToken = "some-jwt-token";
+    LocalDate blockDay = LocalDate.now().plusDays(10);
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(blockDay);
+    request.setEndDate(blockDay);
+
+    UnitDto mockUnit = new UnitDto();
+    mockUnit.setPricePerNight(new BigDecimal("200.00"));
+
+    // Mock unit ownership check
+    when(restTemplate.getForObject(
+            eq("http://property-service/api/properties/units/ids/{ownerId}"),
+            eq(UUID[].class),
+            eq(actorId)))
+        .thenReturn(new UUID[] {unitId});
+
+    when(restTemplate.exchange(
+            anyString(),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(UnitDto.class),
+            any(UUID.class)))
+        .thenReturn(ResponseEntity.ok(mockUnit));
+
+    when(repository.findByUnitId(unitId)).thenReturn(List.of());
+    when(repository.save(any(Reservation.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    Reservation created = service.createReservation(actorId, false, true, request, mockToken);
+
+    assertNotNull(created);
+    assertEquals(actorId, created.getUserId());
+    assertNull(created.getGuestEmail());
+    assertEquals(ReservationStatus.BLOCKED, created.getStatus());
+    assertEquals(blockDay, created.getStartDate());
+    assertEquals(blockDay, created.getEndDate());
+    assertEquals(0, BigDecimal.ZERO.compareTo(created.getTotalPrice()));
+    verify(emailService, never()).sendReservationCreated(any(), any());
+  }
+
+  @Test
+  void shouldFailCreateReservation_whenNormalReservationHasZeroBillableNights() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ReservationService service =
+        new ReservationService(
+            repository,
+            restTemplate,
+            mock(NbpExchangeRateClient.class),
+            mock(EmailNotificationService.class),
+            new BusinessDateProvider("Europe/Warsaw"));
+
+    UUID userId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    String mockToken = "some-jwt-token";
+    LocalDate sameDay = LocalDate.now().plusDays(10);
+
+    CreateReservationRequest request = new CreateReservationRequest();
+    request.setUnitId(unitId);
+    request.setStartDate(sameDay);
+    request.setEndDate(sameDay);
+    request.setStatus(ReservationStatus.PENDING);
+
+    when(repository.findByUnitId(unitId)).thenReturn(List.of());
+
+    ResponseStatusException exception =
+        assertThrows(
+            ResponseStatusException.class,
+            () -> service.createReservation(userId, request, mockToken));
+
+    assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+    assertTrue(exception.getReason().contains("Reservation must include at least one billable night"));
+  }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceValidationTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceValidationTest.java
@@ -52,9 +52,9 @@ class ReservationServiceValidationTest {
   }
 
   @Test
-  void shouldThrow_whenFromNotBeforeTo() {
+  void shouldThrow_whenFromAfterTo() {
     LocalDate from = LocalDate.now().plusDays(5);
-    LocalDate to = LocalDate.now().plusDays(5);
+    LocalDate to = LocalDate.now().plusDays(4);
 
     UUID unitId = UUID.randomUUID();
 

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationStatusValidatorTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationStatusValidatorTest.java
@@ -112,4 +112,20 @@ class ReservationStatusValidatorTest {
         IllegalStateException.class,
         () -> validator.validateTransition(ReservationStatus.CANCELLED, target));
   }
+
+  @Test
+  void shouldAllowTransitionFromBlockedToCancelled() {
+    assertDoesNotThrow(
+        () -> validator.validateTransition(ReservationStatus.BLOCKED, ReservationStatus.CANCELLED));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ReservationStatus.class,
+      names = {"PENDING", "CONFIRMED", "COMPLETED"})
+  void shouldBlockTransitionsFromBlockedExceptCancelled(ReservationStatus target) {
+    assertThrows(
+        IllegalStateException.class,
+        () -> validator.validateTransition(ReservationStatus.BLOCKED, target));
+  }
 }


### PR DESCRIPTION
## Summary
This pull request implements administrative manual availability management capabilities on the Occupancy Calendar. Property owners and administrators can now directly book a unit (bypassing the standard Stripe guest payment checkout) or block off units for maintenance. It supports single-day blocking, updates overlap checking rules on both backend and frontend, and provides solid, clean visual modal components with inline calendar overlap validations.

## Linked issue
Closes #128 

## Scope of changes
### 1. Database & Migrations
- Added database migration `V21__allow_single_day_blocks.sql` modifying the constraints of the `reservations` table to allow single-day blocks where `end_date >= start_date` (changing from strict `>`).

### 2. Backend changes (`reservation-service`)
- **`ReservationStatus.java`**: Added new `BLOCKED` status representing administrative blocks.
- **`ReservationStatusValidator.java`**: Configured transition machine validation to allow `BLOCKED` status to transition only to `CANCELLED`.
- **`EmailNotificationService.java`**: Styled `BLOCKED` status and disabled email notification triggers for blocks.
- **`CreateReservationRequest.java`**: Extended request body DTO payload to optionally accept `guestEmail` and custom `status`.
- **`ReservationController.java`**: Extracted guest email from request DTO instead of forcing authenticated user's email.
- **`ReservationService.java`**:
  - Relaxed check-availability logic to allow same-day dates (`from == to`).
  - Rewrote calendar overlap calculations to support inclusive day blocks (`[from, to - 1]` for reservations vs `[from, from]` for single-day blocks).
  - Saved custom status and bypassed email delivery if the request is configured with `BLOCKED`.
- **Unit Tests**: Updated `ReservationServiceTest.java` and `ReservationServiceValidationTest.java` to test invalid date ranges chronologically (`from > to`) now that single-day bookings are valid.

### 3. Frontend Client APIs & Mocking
- **`reservationApi.ts`**: Introduced `createManualReservation` POST payload mapper to request manual bookings with the `CONFIRMED` status.
- **`availabilityApi.ts`**: Introduced `createBlock` POST payload mapper to request administrative maintenance blocks with the `BLOCKED` status.

### 4. Frontend UI Components & Calendar Page
- **`ManualReservationModal.tsx`**: Created a clean modal to book a unit manually using guest details, check-in/out dates, and notes. Includes solid white background (`bg-[#FFFFFF]`) and client-side validation to block double-bookings by verifying availability against current unit occupancies.
- **`BlockDatesModal.tsx`**: Created a clean modal to block room availability. Supports single-day blocks, applies a solid white background (`bg-[#FFFFFF]`), and includes client-side overlap checks.
- **`OccupancyCalendarPage.tsx`**:
  - Relocated header buttons into the Date Anchor filter card, aligned to the right.
  - Linked calendar cell clicks to a Quick Action popup offering both **New Booking** and **Block Dates**.
  - Configured modals to conditionally mount and pass active calendar occupancies.
  - Implemented calendar state refresh triggers on modal success callbacks.

## Testing status
- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass

## Checklist
- [x] PR title is clear and meaningful
- [ ] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
- [x] Ready for review