### PR TITLE
Move footer to App and render it conditionally

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import './App.css'
-import {Routes, Route} from "react-router-dom"
+import {Routes, Route, useLocation} from "react-router-dom"
 import Navbar from "./components/Navbar"
 import RegisterForm from "./components/RegisterForm"
 import LoginForm from "./components/LoginForm.tsx";
@@ -30,176 +30,187 @@ import EditPropertyImages from "./pages/EditPropertyImages.tsx";
 import EditUnitImages from "./pages/EditUnitImages.tsx";
 import AboutPage from "./pages/AboutPage";
 import DemoModeBanner from "./components/DemoModeBanner";
+import Footer from "./components/landing/Footer";
+
+const FULL_SCREEN_ROUTES = ["/login", "/register", "/payment-cancel"];
 
 function App() {
+    const location = useLocation();
+    const showFooter = !FULL_SCREEN_ROUTES.some((path) => location.pathname.includes(path));
+
     return (
         <CurrencyProvider>
-            <DemoModeBanner/>
-            <Navbar/>
-            <Routes>
-                <Route path="/" element={<HomePage/>}/>
-                <Route path="/about" element={<AboutPage/>}/>
-                <Route path="/register" element={<RegisterForm/>}/>
-                <Route path="/login" element={<LoginForm/>}/>
-                <Route
-                    path="/admin/dashboard"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
-                            <DashboardPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/admin/logs"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_ADMIN']}>
-                            <div className="p-8 max-w-7xl mx-auto min-h-screen text-[#1A1A1A]">
-                                <AdminSystemEventsPage/>
-                            </div>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/admin/reservations"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
-                            <AdminReservationList/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/admin/occupancy"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
-                            <OccupancyCalendarPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/my-reservations"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_GUEST']}>
-                            <MyReservationsPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/reservations/:id"
-                    element={
-                        <ProtectedRoute allowedRoles={[]}>
-                            <ReservationDetailsPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/profile"
-                    element={
-                        <ProtectedRoute>
-                            <ProfilePage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route path="/properties" element={<PropertiesPage/>}/>
-                <Route path="/catalog" element={<PropertiesPage/>}/>
-                <Route path="/property/:id" element={<PropertyDetailsPage/>}/>
-                <Route
-                    path="/checkout"
-                    element={
-                        <ProtectedRoute>
-                            <CheckoutPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route path="/payment-cancel" element={<PaymentCancelPage/>}/>
-                <Route
-                    path="/settlements/:id"
-                    element={
-                        <ProtectedRoute allowedRoles={[]}>
-                            <SettlementDetailsPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/settlements/:settlementId/meter-readings"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_GUEST']}>
-                            <MeterReadingsPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/admin/settlements/:settlementId/meter-readings"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
-                            <AdminMeterReadingsPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <OwnerPropertiesPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties/:propertyId/units"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <OwnerPropertyUnitsPage/>
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties/new"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <CreatePropertyPage />
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties/:propertyId/edit"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <EditPropertyPage />
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties/:propertyId/units/new"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <CreateUnitPage />
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties/:propertyId/units/:unitId/edit"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <EditUnitPage />
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties/:propertyId/images"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <EditPropertyImages />
-                        </ProtectedRoute>
-                    }
-                />
-                <Route
-                    path="/owner/properties/:propertyId/units/:unitId/images"
-                    element={
-                        <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
-                            <EditUnitImages />
-                        </ProtectedRoute>
-                    }
-                />
-            </Routes>
+            <div className="min-h-screen flex flex-col bg-card">
+                <DemoModeBanner/>
+                <Navbar/>
+                <main className="flex-1">
+                    <Routes>
+                        <Route path="/" element={<HomePage/>}/>
+                        <Route path="/about" element={<AboutPage/>}/>
+                        <Route path="/register" element={<RegisterForm/>}/>
+                        <Route path="/login" element={<LoginForm/>}/>
+                        <Route
+                            path="/admin/dashboard"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
+                                    <DashboardPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/logs"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_ADMIN']}>
+                                    <div className="p-8 max-w-7xl mx-auto min-h-screen text-[#1A1A1A]">
+                                        <AdminSystemEventsPage/>
+                                    </div>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/reservations"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
+                                    <AdminReservationList/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/occupancy"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
+                                    <OccupancyCalendarPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/my-reservations"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_GUEST']}>
+                                    <MyReservationsPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/reservations/:id"
+                            element={
+                                <ProtectedRoute allowedRoles={[]}>
+                                    <ReservationDetailsPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/profile"
+                            element={
+                                <ProtectedRoute>
+                                    <ProfilePage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route path="/properties" element={<PropertiesPage/>}/>
+                        <Route path="/catalog" element={<PropertiesPage/>}/>
+                        <Route path="/property/:id" element={<PropertyDetailsPage/>}/>
+                        <Route
+                            path="/checkout"
+                            element={
+                                <ProtectedRoute>
+                                    <CheckoutPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route path="/payment-cancel" element={<PaymentCancelPage/>}/>
+                        <Route
+                            path="/settlements/:id"
+                            element={
+                                <ProtectedRoute allowedRoles={[]}>
+                                    <SettlementDetailsPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/settlements/:settlementId/meter-readings"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_GUEST']}>
+                                    <MeterReadingsPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/admin/settlements/:settlementId/meter-readings"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_ADMIN', 'ROLE_OWNER']}>
+                                    <AdminMeterReadingsPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <OwnerPropertiesPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties/:propertyId/units"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <OwnerPropertyUnitsPage/>
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties/new"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <CreatePropertyPage />
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties/:propertyId/edit"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <EditPropertyPage />
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties/:propertyId/units/new"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <CreateUnitPage />
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties/:propertyId/units/:unitId/edit"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <EditUnitPage />
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties/:propertyId/images"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <EditPropertyImages />
+                                </ProtectedRoute>
+                            }
+                        />
+                        <Route
+                            path="/owner/properties/:propertyId/units/:unitId/images"
+                            element={
+                                <ProtectedRoute allowedRoles={['ROLE_OWNER']}>
+                                    <EditUnitImages />
+                                </ProtectedRoute>
+                            }
+                        />
+                    </Routes>
+                </main>
+                {showFooter && <Footer/>}
+            </div>
         </CurrencyProvider>
     )
 }

--- a/frontend/src/components/landing/Footer.tsx
+++ b/frontend/src/components/landing/Footer.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 export default function Footer() {
   return (
     <footer className="bg-[#4E2723] text-white pt-24 pb-12 px-4 md:px-12 lg:px-20 w-full mt-10 transition-colors duration-300">
@@ -17,7 +19,7 @@ export default function Footer() {
           <div className="text-left">
             <h3 className="font-bold text-xl mb-6 tracking-wide text-white text-left">Company</h3>
             <ul className="space-y-4 text-white/80 text-lg text-left">
-              <li className="text-left"><a href="#" className="hover:text-white transition-colors block text-left">About us</a></li>
+              <li className="text-left"><Link to="/about" className="hover:text-white transition-colors block text-left">About us</Link></li>
               <li className="text-left"><a href="#" className="hover:text-white transition-colors block text-left">Press room</a></li>
             </ul>
           </div>

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,5 +1,4 @@
 import { Brain, Scan, Calendar, LayoutDashboard, Server, Database, Code } from 'lucide-react';
-import Footer from '../components/landing/Footer';
 
 interface TeamMember {
     name: string;
@@ -388,7 +387,6 @@ export default function AboutPage() {
                 </div>
 
             </div>
-            <Footer />
         </div>
     );
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,7 +7,6 @@ import ExploreSection from '../components/landing/ExploreSection';
 import BlogSection from '../components/landing/BlogSection';
 import NewsletterSection from '../components/landing/NewsletterSection';
 import TrustBadges from '../components/landing/TrustBadges';
-import Footer from '../components/landing/Footer';
 import DemoRoleSelector from "../components/DemoRoleSelector";
 import { IS_DEMO_MODE } from "../api/apiConfig";
 
@@ -58,7 +57,6 @@ export default function HomePage() {
             <BlogSection />
             <NewsletterSection />
             <TrustBadges />
-            <Footer />
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Introduce a single app-level Footer rendered from `App.tsx` inside a shared flex column layout. The footer now appears consistently across standard application pages instead of being rendered only on selected pages.

The "About us" footer link was updated to navigate to `/about`. All other footer links and social links were intentionally left unchanged as MVP placeholders.

## Linked issue

Closes #150

## Scope of changes

- Added app-level footer rendering in `App.tsx` using a `min-h-screen flex flex-col` layout with a growing `main` section.
- Removed duplicated/local footer rendering from `HomePage` and `AboutPage`.
- Updated the footer "About us" link to use React Router navigation to `/about`.
- Kept all remaining footer placeholder links unchanged intentionally for the semester MVP.
- Hid the footer on full-screen routes: `/login`, `/register`, and `/payment-cancel`.

## Testing status

- [x] Tested locally
- [x] Relevant tests added - not applicable, layout-only frontend polish
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable
- [x] Not applicable for backend, OpenAPI, database, and service-level changes

Manual verification performed:

- [x] Landing page still renders correctly with the footer.
- [x] `/about` is reachable from the footer "About us" link.
- [x] Footer appears on standard application pages outside the landing page.
- [x] Footer does not duplicate on `HomePage` or `AboutPage`.
- [x] Footer is not displayed on full-screen auth/payment-cancel routes.
- [x] Placeholder footer links remain unchanged except for "About us".

## Checklist

- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed - not needed
- [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area - not needed
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules - not applicable
- [x] Ready for review