### PR TITLE
Add water billing preview and settlement items

### DIFF
--- a/frontend/src/api/propertyApi.ts
+++ b/frontend/src/api/propertyApi.ts
@@ -5,6 +5,7 @@ import {
     demoUnitsByProperty,
     getDemoUnits,
 } from "../demo/demoProperties";
+import type { UnitSettlementItem } from "../types/property";
 
 const API_URL = `${GATEWAY_BASE_URL}/api`;
 
@@ -88,6 +89,25 @@ export async function getUnit(unitId: string, currency: string = "PLN") {
     }
 
     const res = await fetch(`${API_URL}/properties/units/${unitId}?currency=${currency}`);
+    return res.json();
+}
+
+export async function getUnitSettlementItems(unitId: string): Promise<UnitSettlementItem[]> {
+    if (IS_DEMO_MODE) {
+        return [
+            {
+                id: `${unitId}-demo-water-tariff`,
+                unitId,
+                settlementItemType: "WATER",
+                pricePerUnit: 12,
+                measurementUnit: "M3",
+                billingType: "PER_USAGE",
+            },
+        ];
+    }
+
+    const res = await fetch(`${API_URL}/properties/units/${unitId}/settlement-items`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return res.json();
 }
 

--- a/frontend/src/components/WaterRateTooltip.tsx
+++ b/frontend/src/components/WaterRateTooltip.tsx
@@ -1,33 +1,91 @@
+import { useId, useState } from "react";
+import type { FocusEvent } from "react";
+
 type WaterRateTooltipProps = {
     text: string;
-    align?: "left" | "right";
+    value: string;
+    label?: string;
     iconClassName?: string;
     panelClassName?: string;
+    labelClassName?: string;
+    valueClassName?: string;
 };
 
 export default function WaterRateTooltip({
     text,
-    align = "left",
+    value,
+    label = "Rate",
     iconClassName = "border-brand-accent text-brand-muted bg-white",
-    panelClassName = "border-brand-accent bg-white text-brand-main shadow-xl",
+    panelClassName = "border-brand-accent bg-white text-brand-main shadow-sm",
+    labelClassName = "text-brand-muted font-medium",
+    valueClassName = "font-semibold text-brand-main",
 }: WaterRateTooltipProps) {
-    const alignmentClass = align === "right" ? "right-0" : "left-0";
+    const tooltipId = useId();
+    const [isHovered, setIsHovered] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+    const [isPinned, setIsPinned] = useState(false);
+    const [isHoverSuppressed, setIsHoverSuppressed] = useState(false);
+    const isOpen = isHovered || isFocused || isPinned;
+
+    const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+            setIsFocused(false);
+            setIsPinned(false);
+        }
+    };
 
     return (
-        <span className="group relative isolate inline-flex overflow-visible">
-            <button
-                type="button"
-                aria-label="Water rate conversion"
-                className={`inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px] font-bold cursor-help focus:outline-none focus:ring-2 focus:ring-brand-primary/20 ${iconClassName}`}
-            >
-                ?
-            </button>
-            <span
-                role="tooltip"
-                className={`pointer-events-none absolute top-full ${alignmentClass} z-[9999] mt-2 hidden w-64 max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border px-3 py-2 text-left text-xs font-medium leading-snug group-hover:block group-focus-within:block ${panelClassName}`}
-            >
-                {text}
-            </span>
-        </span>
+        <div
+            className="space-y-2 overflow-visible"
+            onMouseEnter={() => {
+                if (!isHoverSuppressed) setIsHovered(true);
+            }}
+            onMouseLeave={() => {
+                setIsHovered(false);
+                setIsPinned(false);
+                setIsHoverSuppressed(false);
+            }}
+            onFocus={() => setIsFocused(true)}
+            onBlur={handleBlur}
+        >
+            <div className="grid grid-cols-[auto,minmax(0,1fr)] items-start gap-x-4 gap-y-1">
+                <span className={`inline-flex items-center gap-1 min-w-0 ${labelClassName}`}>
+                    {label}
+                    <button
+                        type="button"
+                        aria-label="Water rate conversion"
+                        aria-expanded={isOpen}
+                        aria-controls={tooltipId}
+                        onClick={() => {
+                            if (isPinned) {
+                                setIsPinned(false);
+                                setIsFocused(false);
+                                setIsHovered(false);
+                                setIsHoverSuppressed(true);
+                            } else {
+                                setIsPinned(true);
+                                setIsHoverSuppressed(false);
+                            }
+                        }}
+                        className={`inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border text-[10px] font-bold cursor-help focus:outline-none focus:ring-2 focus:ring-brand-primary/20 ${iconClassName}`}
+                    >
+                        ?
+                    </button>
+                </span>
+                <span className={`min-w-0 whitespace-normal break-words text-right leading-snug ${valueClassName}`}>
+                    {value}
+                </span>
+            </div>
+
+            {isOpen && (
+                <div
+                    id={tooltipId}
+                    role="tooltip"
+                    className={`w-full rounded-lg border px-3 py-2 text-xs font-medium leading-snug ${panelClassName}`}
+                >
+                    {text}
+                </div>
+            )}
+        </div>
     );
 }

--- a/frontend/src/components/WaterRateTooltip.tsx
+++ b/frontend/src/components/WaterRateTooltip.tsx
@@ -1,0 +1,29 @@
+type WaterRateTooltipProps = {
+    text: string;
+    iconClassName?: string;
+    panelClassName?: string;
+};
+
+export default function WaterRateTooltip({
+    text,
+    iconClassName = "border-brand-accent text-brand-muted bg-white",
+    panelClassName = "bg-white border-brand-accent text-brand-main shadow-lg",
+}: WaterRateTooltipProps) {
+    return (
+        <span className="relative inline-flex group">
+            <button
+                type="button"
+                aria-label="Water rate conversion"
+                className={`inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px] font-bold cursor-help focus:outline-none focus:ring-2 focus:ring-brand-primary/20 ${iconClassName}`}
+            >
+                ?
+            </button>
+            <span
+                role="tooltip"
+                className={`pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden w-56 -translate-x-1/2 rounded-lg px-3 py-2 text-left text-xs font-medium leading-snug group-hover:block group-focus-within:block ${panelClassName}`}
+            >
+                {text}
+            </span>
+        </span>
+    );
+}

--- a/frontend/src/components/WaterRateTooltip.tsx
+++ b/frontend/src/components/WaterRateTooltip.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { FocusEvent } from "react";
 
 type WaterRateTooltipProps = {
@@ -21,11 +21,28 @@ export default function WaterRateTooltip({
     valueClassName = "font-semibold text-brand-main",
 }: WaterRateTooltipProps) {
     const tooltipId = useId();
-    const [isHovered, setIsHovered] = useState(false);
+    const closeTimerRef = useRef<number | null>(null);
+    const [isIconHovered, setIsIconHovered] = useState(false);
+    const [isPanelHovered, setIsPanelHovered] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
     const [isPinned, setIsPinned] = useState(false);
-    const [isHoverSuppressed, setIsHoverSuppressed] = useState(false);
-    const isOpen = isHovered || isFocused || isPinned;
+    const [isIconHoverSuppressed, setIsIconHoverSuppressed] = useState(false);
+    const isOpen = isIconHovered || isPanelHovered || isFocused || isPinned;
+
+    const clearCloseTimer = () => {
+        if (closeTimerRef.current !== null) {
+            window.clearTimeout(closeTimerRef.current);
+            closeTimerRef.current = null;
+        }
+    };
+
+    useEffect(() => {
+        return () => {
+            if (closeTimerRef.current !== null) {
+                window.clearTimeout(closeTimerRef.current);
+            }
+        };
+    }, []);
 
     const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
         if (!event.currentTarget.contains(event.relatedTarget)) {
@@ -37,14 +54,6 @@ export default function WaterRateTooltip({
     return (
         <div
             className="space-y-2 overflow-visible"
-            onMouseEnter={() => {
-                if (!isHoverSuppressed) setIsHovered(true);
-            }}
-            onMouseLeave={() => {
-                setIsHovered(false);
-                setIsPinned(false);
-                setIsHoverSuppressed(false);
-            }}
             onFocus={() => setIsFocused(true)}
             onBlur={handleBlur}
         >
@@ -56,15 +65,29 @@ export default function WaterRateTooltip({
                         aria-label="Water rate conversion"
                         aria-expanded={isOpen}
                         aria-controls={tooltipId}
+                        onMouseEnter={() => {
+                            clearCloseTimer();
+                            if (!isIconHoverSuppressed) {
+                                setIsIconHovered(true);
+                            }
+                        }}
+                        onMouseLeave={() => {
+                            clearCloseTimer();
+                            closeTimerRef.current = window.setTimeout(() => {
+                                setIsIconHovered(false);
+                                setIsIconHoverSuppressed(false);
+                            }, 120);
+                        }}
                         onClick={() => {
                             if (isPinned) {
                                 setIsPinned(false);
                                 setIsFocused(false);
-                                setIsHovered(false);
-                                setIsHoverSuppressed(true);
+                                setIsIconHovered(false);
+                                setIsPanelHovered(false);
+                                setIsIconHoverSuppressed(true);
                             } else {
                                 setIsPinned(true);
-                                setIsHoverSuppressed(false);
+                                setIsIconHoverSuppressed(false);
                             }
                         }}
                         className={`inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border text-[10px] font-bold cursor-help focus:outline-none focus:ring-2 focus:ring-brand-primary/20 ${iconClassName}`}
@@ -81,6 +104,11 @@ export default function WaterRateTooltip({
                 <div
                     id={tooltipId}
                     role="tooltip"
+                    onMouseEnter={() => {
+                        clearCloseTimer();
+                        setIsPanelHovered(true);
+                    }}
+                    onMouseLeave={() => setIsPanelHovered(false)}
                     className={`w-full rounded-lg border px-3 py-2 text-xs font-medium leading-snug ${panelClassName}`}
                 >
                     {text}

--- a/frontend/src/components/WaterRateTooltip.tsx
+++ b/frontend/src/components/WaterRateTooltip.tsx
@@ -1,16 +1,20 @@
 type WaterRateTooltipProps = {
     text: string;
+    align?: "left" | "right";
     iconClassName?: string;
     panelClassName?: string;
 };
 
 export default function WaterRateTooltip({
     text,
+    align = "left",
     iconClassName = "border-brand-accent text-brand-muted bg-white",
-    panelClassName = "bg-white border-brand-accent text-brand-main shadow-lg",
+    panelClassName = "border-brand-accent bg-white text-brand-main shadow-xl",
 }: WaterRateTooltipProps) {
+    const alignmentClass = align === "right" ? "right-0" : "left-0";
+
     return (
-        <span className="relative inline-flex group">
+        <span className="group relative isolate inline-flex overflow-visible">
             <button
                 type="button"
                 aria-label="Water rate conversion"
@@ -20,7 +24,7 @@ export default function WaterRateTooltip({
             </button>
             <span
                 role="tooltip"
-                className={`pointer-events-none absolute bottom-full left-1/2 z-30 mb-2 hidden w-56 -translate-x-1/2 rounded-lg px-3 py-2 text-left text-xs font-medium leading-snug group-hover:block group-focus-within:block ${panelClassName}`}
+                className={`pointer-events-none absolute top-full ${alignmentClass} z-[9999] mt-2 hidden w-64 max-w-[min(16rem,calc(100vw-2rem))] rounded-lg border px-3 py-2 text-left text-xs font-medium leading-snug group-hover:block group-focus-within:block ${panelClassName}`}
             >
                 {text}
             </span>

--- a/frontend/src/components/WaterRateTooltip.tsx
+++ b/frontend/src/components/WaterRateTooltip.tsx
@@ -23,11 +23,11 @@ export default function WaterRateTooltip({
     const tooltipId = useId();
     const closeTimerRef = useRef<number | null>(null);
     const [isIconHovered, setIsIconHovered] = useState(false);
-    const [isPanelHovered, setIsPanelHovered] = useState(false);
+    const [isComponentHovered, setIsComponentHovered] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
     const [isPinned, setIsPinned] = useState(false);
     const [isIconHoverSuppressed, setIsIconHoverSuppressed] = useState(false);
-    const isOpen = isIconHovered || isPanelHovered || isFocused || isPinned;
+    const isOpen = isIconHovered || isComponentHovered || isFocused || isPinned;
 
     const clearCloseTimer = () => {
         if (closeTimerRef.current !== null) {
@@ -51,10 +51,25 @@ export default function WaterRateTooltip({
         }
     };
 
+    const scheduleHoverClose = () => {
+        clearCloseTimer();
+        closeTimerRef.current = window.setTimeout(() => {
+            setIsIconHovered(false);
+            setIsComponentHovered(false);
+            setIsIconHoverSuppressed(false);
+        }, 200);
+    };
+
     return (
         <div
             className="space-y-2 overflow-visible"
-            onFocus={() => setIsFocused(true)}
+            onMouseEnter={() => {
+                clearCloseTimer();
+                if (isOpen) {
+                    setIsComponentHovered(true);
+                }
+            }}
+            onMouseLeave={scheduleHoverClose}
             onBlur={handleBlur}
         >
             <div className="grid grid-cols-[auto,minmax(0,1fr)] items-start gap-x-4 gap-y-1">
@@ -65,28 +80,24 @@ export default function WaterRateTooltip({
                         aria-label="Water rate conversion"
                         aria-expanded={isOpen}
                         aria-controls={tooltipId}
+                        onFocus={() => setIsFocused(true)}
                         onMouseEnter={() => {
                             clearCloseTimer();
                             if (!isIconHoverSuppressed) {
                                 setIsIconHovered(true);
+                                setIsComponentHovered(true);
                             }
-                        }}
-                        onMouseLeave={() => {
-                            clearCloseTimer();
-                            closeTimerRef.current = window.setTimeout(() => {
-                                setIsIconHovered(false);
-                                setIsIconHoverSuppressed(false);
-                            }, 120);
                         }}
                         onClick={() => {
                             if (isPinned) {
                                 setIsPinned(false);
                                 setIsFocused(false);
                                 setIsIconHovered(false);
-                                setIsPanelHovered(false);
+                                setIsComponentHovered(false);
                                 setIsIconHoverSuppressed(true);
                             } else {
                                 setIsPinned(true);
+                                setIsComponentHovered(true);
                                 setIsIconHoverSuppressed(false);
                             }
                         }}
@@ -106,9 +117,8 @@ export default function WaterRateTooltip({
                     role="tooltip"
                     onMouseEnter={() => {
                         clearCloseTimer();
-                        setIsPanelHovered(true);
+                        setIsComponentHovered(true);
                     }}
-                    onMouseLeave={() => setIsPanelHovered(false)}
                     className={`w-full rounded-lg border px-3 py-2 text-xs font-medium leading-snug ${panelClassName}`}
                 >
                     {text}

--- a/frontend/src/pages/CheckoutPage.tsx
+++ b/frontend/src/pages/CheckoutPage.tsx
@@ -739,7 +739,7 @@ export default function CheckoutPage() {
                                     <span className="text-lg">{displayTotalPrice}</span>
                                 </div>
 
-                                <div className="border-t border-dashed border-brand-accent pt-4 space-y-2">
+                                <div className="border-t border-dashed border-brand-accent pt-4 space-y-2 overflow-visible">
                                     <div>
                                         <h5 className="font-bold text-xs uppercase tracking-wider text-brand-muted">Water billing</h5>
                                         <p className="text-xs text-brand-muted mt-1">Water is billed separately after your stay.</p>
@@ -749,7 +749,7 @@ export default function CheckoutPage() {
                                         <p className="text-xs text-brand-muted font-medium">Checking water tariff...</p>
                                     ) : waterEstimate ? (
                                         <div className="space-y-1.5">
-                                            <div className="flex justify-between items-start gap-4">
+                                            <div className="relative flex justify-between items-start gap-4 overflow-visible">
                                                 <span className="text-brand-muted font-medium inline-flex items-center gap-1">
                                                     Rate
                                                     <WaterRateTooltip text={waterEstimate.tooltip} />

--- a/frontend/src/pages/CheckoutPage.tsx
+++ b/frontend/src/pages/CheckoutPage.tsx
@@ -749,13 +749,7 @@ export default function CheckoutPage() {
                                         <p className="text-xs text-brand-muted font-medium">Checking water tariff...</p>
                                     ) : waterEstimate ? (
                                         <div className="space-y-1.5">
-                                            <div className="relative flex justify-between items-start gap-4 overflow-visible">
-                                                <span className="text-brand-muted font-medium inline-flex items-center gap-1">
-                                                    Rate
-                                                    <WaterRateTooltip text={waterEstimate.tooltip} />
-                                                </span>
-                                                <span className="font-semibold text-right">{waterEstimate.rate}</span>
-                                            </div>
+                                            <WaterRateTooltip text={waterEstimate.tooltip} value={waterEstimate.rate} />
                                             <div className="flex justify-between items-start gap-4">
                                                 <span className="text-brand-muted font-medium">Estimated usage</span>
                                                 <span className="font-semibold text-right">{waterEstimate.usage}</span>

--- a/frontend/src/pages/CheckoutPage.tsx
+++ b/frontend/src/pages/CheckoutPage.tsx
@@ -3,9 +3,19 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { createReservation } from "../api/reservationApi";
 import { createCheckoutSession } from "../api/billingApi";
 import { getUserProfile } from "../api/userApi";
-import type { Property, Unit } from "../types/property";
+import { getUnitSettlementItems } from "../api/propertyApi";
+import type { Property, Unit, UnitSettlementItem } from "../types/property";
 import { format, parseISO } from "date-fns";
 import { IS_DEMO_MODE } from "../api/apiConfig";
+import {
+    calculateStayNights,
+    calculateWaterUsageRange,
+    findWaterUsageTariff,
+    formatMoneyRange,
+    formatUsageRange,
+    formatWaterRate,
+    getRatePerLiterTooltip,
+} from "../utils/waterBilling";
 
 interface CheckoutState {
     property: Property;
@@ -32,6 +42,7 @@ interface GuestForm {
     companyAddress: string;
     acceptRules: boolean;
     acceptPrivacy: boolean;
+    acceptWaterBilling: boolean;
 }
 
 interface FormErrors {
@@ -64,12 +75,15 @@ export default function CheckoutPage() {
         taxId: "",
         companyAddress: "",
         acceptRules: false,
-        acceptPrivacy: false
+        acceptPrivacy: false,
+        acceptWaterBilling: false
     });
     const [errors, setErrors] = useState<FormErrors>({});
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState<string | null>(null);
     const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
+    const [settlementItems, setSettlementItems] = useState<UnitSettlementItem[]>([]);
+    const [waterTariffLoaded, setWaterTariffLoaded] = useState(false);
 
     useEffect(() => {
         getUserProfile()
@@ -84,6 +98,27 @@ export default function CheckoutPage() {
             .catch(() => {
             });
     }, []);
+
+    useEffect(() => {
+        if (!state?.unit.id) return;
+
+        let isActive = true;
+
+        getUnitSettlementItems(state.unit.id)
+            .then((items) => {
+                if (isActive) setSettlementItems(items);
+            })
+            .catch(() => {
+                if (isActive) setSettlementItems([]);
+            })
+            .finally(() => {
+                if (isActive) setWaterTariffLoaded(true);
+            });
+
+        return () => {
+            isActive = false;
+        };
+    }, [state?.unit.id]);
 
     if (!state) {
         return (
@@ -195,7 +230,7 @@ export default function CheckoutPage() {
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         if (!validate()) return;
-        if (!form.acceptRules || !form.acceptPrivacy) return;
+        if (!form.acceptRules || !form.acceptPrivacy || !form.acceptWaterBilling) return;
 
         setIsSubmitting(true);
         setSubmitError(null);
@@ -258,6 +293,21 @@ export default function CheckoutPage() {
         }
     };
 
+    const waterTariff = findWaterUsageTariff(settlementItems);
+    const calculationNights = calculateStayNights(checkIn, checkOut);
+    const waterUsageRange = calculateWaterUsageRange(unit.capacity, calculationNights);
+    const waterCurrencyInfo = unit.currencyInfo && unit.currencyInfo.displayCurrency !== "PLN"
+        ? unit.currencyInfo
+        : undefined;
+    const waterEstimate = waterTariff
+        ? {
+            rate: formatWaterRate(waterTariff.pricePerUnit),
+            usage: formatUsageRange(waterUsageRange),
+            cost: formatMoneyRange(waterUsageRange, waterTariff.pricePerUnit, waterCurrencyInfo),
+            tooltip: getRatePerLiterTooltip(waterTariff.pricePerUnit),
+        }
+        : null;
+
     const displayNightPrice = unit.convertedPricePerNight && unit.currencyInfo && unit.currencyInfo.displayCurrency !== "PLN"
         ? `${unit.convertedPricePerNight.toFixed(2)} ${unit.currencyInfo.displayCurrency}`
         : `${unit.pricePerNight} PLN`;
@@ -279,7 +329,7 @@ export default function CheckoutPage() {
         "Not sure yet"
     ];
 
-    const isLegalUnchecked = !form.acceptRules || !form.acceptPrivacy;
+    const isRequiredAcknowledgementUnchecked = !form.acceptRules || !form.acceptPrivacy || !form.acceptWaterBilling;
 
     return (
         <div className="max-w-7xl mx-auto p-4 sm:p-8 min-h-screen text-brand-main space-y-8">
@@ -555,6 +605,20 @@ export default function CheckoutPage() {
                                     I acknowledge the <a href="#" className="text-brand-primary font-bold hover:underline" onClick={(e) => e.preventDefault()}>Privacy Policy</a> and consent to standard processing of my personal details. <span className="text-red-500">*</span>
                                 </label>
                             </div>
+
+                            <div className="flex items-start gap-3">
+                                <input
+                                    type="checkbox"
+                                    id="acceptWaterBilling"
+                                    name="acceptWaterBilling"
+                                    checked={form.acceptWaterBilling}
+                                    onChange={handleChange}
+                                    className="w-5 h-5 accent-brand-primary rounded border-brand-accent focus:ring-brand-primary text-brand-primary mt-0.5 cursor-pointer flex-shrink-0"
+                                />
+                                <label htmlFor="acceptWaterBilling" className="text-sm text-brand-muted font-medium select-none cursor-pointer leading-tight">
+                                    I accept separate water billing after check-out. <span className="text-red-500">*</span>
+                                </label>
+                            </div>
                         </div>
 
                         {submitError && (
@@ -578,11 +642,11 @@ export default function CheckoutPage() {
                         <div className="pt-4 border-t border-brand-accent hidden lg:block">
                             <button
                                 type="submit"
-                                disabled={isSubmitting || isLegalUnchecked}
+                                disabled={isSubmitting || isRequiredAcknowledgementUnchecked}
                                 className={`w-full py-3.5 px-6 font-bold rounded-lg shadow-sm transition-all duration-200 flex items-center justify-center gap-2 cursor-pointer ${
                                     isSubmitting
                                         ? "bg-brand-muted text-white cursor-wait"
-                                        : isLegalUnchecked
+                                        : isRequiredAcknowledgementUnchecked
                                             ? "bg-brand-accent text-brand-muted opacity-60 cursor-not-allowed"
                                             : "bg-brand-primary text-white hover:bg-brand-primary-hover active:scale-[0.99]"
                                 }`}
@@ -604,8 +668,8 @@ export default function CheckoutPage() {
                                     </>
                                 )}
                             </button>
-                            {isLegalUnchecked && (
-                                <p className="text-center text-xs text-brand-muted mt-2 font-medium">Please accept the legal terms and privacy policies to proceed to payment.</p>
+                            {isRequiredAcknowledgementUnchecked && (
+                                <p className="text-center text-xs text-brand-muted mt-2 font-medium">Please accept all required acknowledgements to proceed to payment.</p>
                             )}
                         </div>
                     </form>
@@ -670,16 +734,53 @@ export default function CheckoutPage() {
                                     <span>Total Price</span>
                                     <span className="text-lg">{displayTotalPrice}</span>
                                 </div>
+
+                                <div className="border-t border-dashed border-brand-accent pt-4 space-y-2">
+                                    <div>
+                                        <h5 className="font-bold text-xs uppercase tracking-wider text-brand-muted">Water billing</h5>
+                                        <p className="text-xs text-brand-muted mt-1">Water is billed separately after your stay.</p>
+                                    </div>
+
+                                    {!waterTariffLoaded ? (
+                                        <p className="text-xs text-brand-muted font-medium">Checking water tariff...</p>
+                                    ) : waterEstimate ? (
+                                        <div className="space-y-1.5">
+                                            <div className="flex justify-between items-start gap-4">
+                                                <span className="text-brand-muted font-medium inline-flex items-center gap-1">
+                                                    Rate
+                                                    <span
+                                                        title={waterEstimate.tooltip}
+                                                        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-brand-accent text-[10px] font-bold text-brand-muted cursor-help"
+                                                    >
+                                                        ?
+                                                    </span>
+                                                </span>
+                                                <span className="font-semibold text-right">{waterEstimate.rate}</span>
+                                            </div>
+                                            <div className="flex justify-between items-start gap-4">
+                                                <span className="text-brand-muted font-medium">Estimated usage</span>
+                                                <span className="font-semibold text-right">{waterEstimate.usage}</span>
+                                            </div>
+                                            <div className="flex justify-between items-start gap-4">
+                                                <span className="text-brand-muted font-medium">Estimated cost</span>
+                                                <span className="font-semibold text-right">{waterEstimate.cost}</span>
+                                            </div>
+                                            <p className="text-xs text-brand-muted">Final cost may be lower or higher based on meter readings.</p>
+                                        </div>
+                                    ) : (
+                                        <p className="text-xs text-brand-muted font-medium">Water may be billed separately after your stay if configured for this unit.</p>
+                                    )}
+                                </div>
                             </div>
 
                             <div className="pt-2 block lg:hidden">
                                 <button
                                     onClick={handleSubmit}
-                                    disabled={isSubmitting || isLegalUnchecked}
+                                    disabled={isSubmitting || isRequiredAcknowledgementUnchecked}
                                     className={`w-full py-3.5 px-6 font-bold rounded-lg shadow-sm transition-all duration-200 flex items-center justify-center gap-2 cursor-pointer ${
                                         isSubmitting
                                             ? "bg-brand-muted text-white cursor-wait"
-                                            : isLegalUnchecked
+                                            : isRequiredAcknowledgementUnchecked
                                                 ? "bg-brand-accent text-brand-muted opacity-60 cursor-not-allowed"
                                                 : "bg-brand-primary text-white hover:bg-brand-primary-hover active:scale-[0.99]"
                                     }`}
@@ -701,8 +802,8 @@ export default function CheckoutPage() {
                                         </>
                                     )}
                                 </button>
-                                {isLegalUnchecked && (
-                                    <p className="text-center text-xs text-brand-muted mt-2 font-medium">Please accept legal agreements in the form above to proceed.</p>
+                                {isRequiredAcknowledgementUnchecked && (
+                                    <p className="text-center text-xs text-brand-muted mt-2 font-medium">Please accept all required acknowledgements in the form above to proceed.</p>
                                 )}
                             </div>
                         </div>

--- a/frontend/src/pages/CheckoutPage.tsx
+++ b/frontend/src/pages/CheckoutPage.tsx
@@ -4,6 +4,7 @@ import { createReservation } from "../api/reservationApi";
 import { createCheckoutSession } from "../api/billingApi";
 import { getUserProfile } from "../api/userApi";
 import { getUnitSettlementItems } from "../api/propertyApi";
+import WaterRateTooltip from "../components/WaterRateTooltip";
 import type { Property, Unit, UnitSettlementItem } from "../types/property";
 import { format, parseISO } from "date-fns";
 import { IS_DEMO_MODE } from "../api/apiConfig";
@@ -301,12 +302,15 @@ export default function CheckoutPage() {
         : undefined;
     const waterEstimate = waterTariff
         ? {
-            rate: formatWaterRate(waterTariff.pricePerUnit),
+            rate: formatWaterRate(waterTariff.pricePerUnit, waterCurrencyInfo),
             usage: formatUsageRange(waterUsageRange),
             cost: formatMoneyRange(waterUsageRange, waterTariff.pricePerUnit, waterCurrencyInfo),
-            tooltip: getRatePerLiterTooltip(waterTariff.pricePerUnit),
+            tooltip: getRatePerLiterTooltip(waterTariff.pricePerUnit, waterCurrencyInfo),
         }
         : null;
+    const waterBillingAcknowledgementCopy = waterTariffLoaded && !waterTariff
+        ? "I understand water may be billed separately after check-out."
+        : "I accept separate water billing after check-out.";
 
     const displayNightPrice = unit.convertedPricePerNight && unit.currencyInfo && unit.currencyInfo.displayCurrency !== "PLN"
         ? `${unit.convertedPricePerNight.toFixed(2)} ${unit.currencyInfo.displayCurrency}`
@@ -616,7 +620,7 @@ export default function CheckoutPage() {
                                     className="w-5 h-5 accent-brand-primary rounded border-brand-accent focus:ring-brand-primary text-brand-primary mt-0.5 cursor-pointer flex-shrink-0"
                                 />
                                 <label htmlFor="acceptWaterBilling" className="text-sm text-brand-muted font-medium select-none cursor-pointer leading-tight">
-                                    I accept separate water billing after check-out. <span className="text-red-500">*</span>
+                                    {waterBillingAcknowledgementCopy} <span className="text-red-500">*</span>
                                 </label>
                             </div>
                         </div>
@@ -731,7 +735,7 @@ export default function CheckoutPage() {
                                 </div>
 
                                 <div className="flex justify-between items-center border-t border-brand-accent pt-4 text-base font-bold text-brand-primary">
-                                    <span>Total Price</span>
+                                    <span>Accommodation total</span>
                                     <span className="text-lg">{displayTotalPrice}</span>
                                 </div>
 
@@ -748,12 +752,7 @@ export default function CheckoutPage() {
                                             <div className="flex justify-between items-start gap-4">
                                                 <span className="text-brand-muted font-medium inline-flex items-center gap-1">
                                                     Rate
-                                                    <span
-                                                        title={waterEstimate.tooltip}
-                                                        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-brand-accent text-[10px] font-bold text-brand-muted cursor-help"
-                                                    >
-                                                        ?
-                                                    </span>
+                                                    <WaterRateTooltip text={waterEstimate.tooltip} />
                                                 </span>
                                                 <span className="font-semibold text-right">{waterEstimate.rate}</span>
                                             </div>

--- a/frontend/src/pages/ReservationDetailsPage.tsx
+++ b/frontend/src/pages/ReservationDetailsPage.tsx
@@ -1,15 +1,32 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { getReservationDetails } from "../api/reservationApi";
+import { getUnit, getUnitSettlementItems } from "../api/propertyApi";
 import type { ReservationDetails } from "../types/reservation";
+import type { UnitSettlementItem } from "../types/property";
 import { getUserRoles } from "../utils/jwtUtils";
 import { Home, Calendar, User, CreditCard, Clock } from "lucide-react";
+import {
+    calculateStayNights,
+    calculateWaterUsageRange,
+    findWaterUsageTariff,
+    formatMoneyRange,
+    formatUsageRange,
+    formatWaterRate,
+    getRatePerLiterTooltip,
+} from "../utils/waterBilling";
 
 export default function ReservationDetailsPage() {
     const { id } = useParams();
     const [reservation, setReservation] = useState<ReservationDetails | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
+    const [waterContext, setWaterContext] = useState<{
+        unitId?: string;
+        items: UnitSettlementItem[];
+        capacity?: number;
+        loaded: boolean;
+    }>({ items: [], loaded: false });
 
     useEffect(() => {
         if (!id) return;
@@ -19,6 +36,35 @@ export default function ReservationDetailsPage() {
             .catch((err) => setError(err.message))
             .finally(() => setLoading(false));
     }, [id]);
+
+    useEffect(() => {
+        if (!reservation?.unitId) return;
+
+        let isActive = true;
+        const displayCurrency = reservation.currencyInfo?.displayCurrency || "PLN";
+
+        Promise.all([
+            getUnit(reservation.unitId, displayCurrency),
+            getUnitSettlementItems(reservation.unitId),
+        ])
+            .then(([unit, items]) => {
+                if (!isActive) return;
+
+                setWaterContext({
+                    unitId: reservation.unitId,
+                    items,
+                    capacity: typeof unit?.capacity === "number" ? unit.capacity : undefined,
+                    loaded: true,
+                });
+            })
+            .catch(() => {
+                if (isActive) setWaterContext({ unitId: reservation.unitId, items: [], loaded: true });
+            });
+
+        return () => {
+            isActive = false;
+        };
+    }, [reservation?.unitId, reservation?.currencyInfo?.displayCurrency]);
 
     if (loading) return <div className="p-8 text-center text-gray-500 font-medium">Loading reservation details...</div>;
     if (error) return <div className="p-8 text-center text-red-600 font-semibold">{error}</div>;
@@ -30,6 +76,19 @@ export default function ReservationDetailsPage() {
     const displayCurrency = reservation.currencyInfo?.displayCurrency || 'PLN';
     const returnPath = isAdminOrOwner ? "/admin/reservations" : "/my-reservations";
     const returnLabel = isAdminOrOwner ? "Back to Reservations Overview" : "Back to My Reservations";
+    const currentWaterContext = waterContext.unitId === reservation.unitId ? waterContext : { items: [], capacity: undefined, loaded: false };
+    const waterTariff = findWaterUsageTariff(currentWaterContext.items);
+    const waterUsageRange = currentWaterContext.capacity
+        ? calculateWaterUsageRange(currentWaterContext.capacity, calculateStayNights(reservation.startDate, reservation.endDate))
+        : null;
+    const waterEstimate = waterTariff && waterUsageRange
+        ? {
+            rate: formatWaterRate(waterTariff.pricePerUnit),
+            usage: formatUsageRange(waterUsageRange),
+            cost: formatMoneyRange(waterUsageRange, waterTariff.pricePerUnit, reservation.currencyInfo),
+            tooltip: getRatePerLiterTooltip(waterTariff.pricePerUnit),
+        }
+        : null;
 
     const formatGuestName = (name: string) => {
         if (!name) return "";
@@ -255,6 +314,41 @@ export default function ReservationDetailsPage() {
                                         </span>
                                     </div>
                                 )}
+
+                                <div className="py-3 border-b border-[#DACDCA]/40 space-y-2">
+                                    <div className="flex items-center justify-between gap-3">
+                                        <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">Water billing</span>
+                                        {waterEstimate && (
+                                            <span
+                                                title={waterEstimate.tooltip}
+                                                className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[#DACDCA] text-[10px] font-bold text-[#7A7A7A] cursor-help"
+                                            >
+                                                ?
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-[#7A7A7A] font-medium">
+                                        Water is billed separately after your stay.
+                                    </p>
+                                    {waterEstimate ? (
+                                        <div className="space-y-1 text-xs">
+                                            <div className="flex justify-between gap-3">
+                                                <span className="text-[#7A7A7A]">Rate</span>
+                                                <span className="font-bold text-[#1A1A1A]">{waterEstimate.rate}</span>
+                                            </div>
+                                            <div className="flex justify-between gap-3">
+                                                <span className="text-[#7A7A7A]">Estimated usage</span>
+                                                <span className="font-bold text-[#1A1A1A]">{waterEstimate.usage}</span>
+                                            </div>
+                                            <div className="flex justify-between gap-3">
+                                                <span className="text-[#7A7A7A]">Estimated cost</span>
+                                                <span className="font-bold text-[#1A1A1A]">{waterEstimate.cost}</span>
+                                            </div>
+                                        </div>
+                                    ) : currentWaterContext.loaded ? (
+                                        <p className="text-xs text-[#7A7A7A]">Final water cost is based on meter readings when configured.</p>
+                                    ) : null}
+                                </div>
                             </div>
                         </div>
 

--- a/frontend/src/pages/ReservationDetailsPage.tsx
+++ b/frontend/src/pages/ReservationDetailsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { getReservationDetails } from "../api/reservationApi";
 import { getUnit, getUnitSettlementItems } from "../api/propertyApi";
+import WaterRateTooltip from "../components/WaterRateTooltip";
 import type { ReservationDetails } from "../types/reservation";
 import type { UnitSettlementItem } from "../types/property";
 import { getUserRoles } from "../utils/jwtUtils";
@@ -83,10 +84,10 @@ export default function ReservationDetailsPage() {
         : null;
     const waterEstimate = waterTariff && waterUsageRange
         ? {
-            rate: formatWaterRate(waterTariff.pricePerUnit),
+            rate: formatWaterRate(waterTariff.pricePerUnit, reservation.currencyInfo),
             usage: formatUsageRange(waterUsageRange),
             cost: formatMoneyRange(waterUsageRange, waterTariff.pricePerUnit, reservation.currencyInfo),
-            tooltip: getRatePerLiterTooltip(waterTariff.pricePerUnit),
+            tooltip: getRatePerLiterTooltip(waterTariff.pricePerUnit, reservation.currencyInfo),
         }
         : null;
 
@@ -319,12 +320,11 @@ export default function ReservationDetailsPage() {
                                     <div className="flex items-center justify-between gap-3">
                                         <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">Water billing</span>
                                         {waterEstimate && (
-                                            <span
-                                                title={waterEstimate.tooltip}
-                                                className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-[#DACDCA] text-[10px] font-bold text-[#7A7A7A] cursor-help"
-                                            >
-                                                ?
-                                            </span>
+                                            <WaterRateTooltip
+                                                text={waterEstimate.tooltip}
+                                                iconClassName="border-[#DACDCA] text-[#7A7A7A] bg-white"
+                                                panelClassName="bg-white border-[#DACDCA] text-[#1A1A1A] shadow-lg"
+                                            />
                                         )}
                                     </div>
                                     <p className="text-xs text-[#7A7A7A] font-medium">

--- a/frontend/src/pages/ReservationDetailsPage.tsx
+++ b/frontend/src/pages/ReservationDetailsPage.tsx
@@ -316,12 +316,13 @@ export default function ReservationDetailsPage() {
                                     </div>
                                 )}
 
-                                <div className="py-3 border-b border-[#DACDCA]/40 space-y-2">
+                                <div className="py-3 border-b border-[#DACDCA]/40 space-y-2 overflow-visible">
                                     <div className="flex items-center justify-between gap-3">
                                         <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">Water billing</span>
                                         {waterEstimate && (
                                             <WaterRateTooltip
                                                 text={waterEstimate.tooltip}
+                                                align="right"
                                                 iconClassName="border-[#DACDCA] text-[#7A7A7A] bg-white"
                                                 panelClassName="bg-white border-[#DACDCA] text-[#1A1A1A] shadow-lg"
                                             />

--- a/frontend/src/pages/ReservationDetailsPage.tsx
+++ b/frontend/src/pages/ReservationDetailsPage.tsx
@@ -319,24 +319,20 @@ export default function ReservationDetailsPage() {
                                 <div className="py-3 border-b border-[#DACDCA]/40 space-y-2 overflow-visible">
                                     <div className="flex items-center justify-between gap-3">
                                         <span className="text-xs font-bold text-[#7A7A7A] uppercase tracking-wider">Water billing</span>
-                                        {waterEstimate && (
-                                            <WaterRateTooltip
-                                                text={waterEstimate.tooltip}
-                                                align="right"
-                                                iconClassName="border-[#DACDCA] text-[#7A7A7A] bg-white"
-                                                panelClassName="bg-white border-[#DACDCA] text-[#1A1A1A] shadow-lg"
-                                            />
-                                        )}
                                     </div>
                                     <p className="text-xs text-[#7A7A7A] font-medium">
                                         Water is billed separately after your stay.
                                     </p>
                                     {waterEstimate ? (
                                         <div className="space-y-1 text-xs">
-                                            <div className="flex justify-between gap-3">
-                                                <span className="text-[#7A7A7A]">Rate</span>
-                                                <span className="font-bold text-[#1A1A1A]">{waterEstimate.rate}</span>
-                                            </div>
+                                            <WaterRateTooltip
+                                                text={waterEstimate.tooltip}
+                                                value={waterEstimate.rate}
+                                                iconClassName="border-[#DACDCA] text-[#7A7A7A] bg-white"
+                                                panelClassName="bg-white border-[#DACDCA] text-[#1A1A1A] shadow-sm"
+                                                labelClassName="text-[#7A7A7A]"
+                                                valueClassName="font-bold text-[#1A1A1A]"
+                                            />
                                             <div className="flex justify-between gap-3">
                                                 <span className="text-[#7A7A7A]">Estimated usage</span>
                                                 <span className="font-bold text-[#1A1A1A]">{waterEstimate.usage}</span>

--- a/frontend/src/types/property.ts
+++ b/frontend/src/types/property.ts
@@ -61,6 +61,15 @@ export interface Unit {
     beds: number;
 }
 
+export interface UnitSettlementItem {
+    id: string;
+    unitId: string;
+    settlementItemType: "ACCOMMODATION" | "DEPOSIT" | "ELECTRICITY" | "WATER" | "CLEANING_FEE" | string;
+    pricePerUnit: number;
+    measurementUnit?: "M3" | "KWH" | string | null;
+    billingType: "FIXED" | "PER_USAGE" | string;
+}
+
 export interface UnitCreateRequest {
     name: string;
     description: string;

--- a/frontend/src/utils/waterBilling.ts
+++ b/frontend/src/utils/waterBilling.ts
@@ -1,0 +1,76 @@
+import type { UnitSettlementItem } from "../types/property";
+
+type CurrencyInfo = {
+    displayCurrency: string;
+    exchangeRate: number;
+};
+
+export type WaterUsageRange = {
+    minUsageM3: number;
+    maxUsageM3: number;
+};
+
+export const M3_LABEL = "m\u00B3";
+
+export function calculateStayNights(checkIn: string, checkOut: string): number {
+    const start = new Date(checkIn).getTime();
+    const end = new Date(checkOut).getTime();
+
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+        return 1;
+    }
+
+    return Math.max(1, Math.ceil((end - start) / (1000 * 60 * 60 * 24)));
+}
+
+export function calculateWaterUsageRange(capacity: number, nights: number): WaterUsageRange {
+    const expectedUsageM3 = capacity * Math.max(1, nights) * 0.1;
+
+    return {
+        minUsageM3: expectedUsageM3 * 0.2,
+        maxUsageM3: expectedUsageM3 * 3.0,
+    };
+}
+
+export function findWaterUsageTariff(items: UnitSettlementItem[]): UnitSettlementItem | undefined {
+    return items.find((item) =>
+        item.settlementItemType === "WATER" &&
+        item.billingType === "PER_USAGE" &&
+        item.measurementUnit === "M3" &&
+        typeof item.pricePerUnit === "number"
+    );
+}
+
+export function formatUsageRange(range: WaterUsageRange): string {
+    return `${formatNumber(range.minUsageM3)}-${formatNumber(range.maxUsageM3)} ${M3_LABEL}`;
+}
+
+export function formatMoneyRange(
+    range: WaterUsageRange,
+    pricePerUnitPln: number,
+    currencyInfo?: CurrencyInfo
+): string {
+    const currency = currencyInfo?.displayCurrency && currencyInfo.displayCurrency !== "PLN" && currencyInfo.exchangeRate > 0
+        ? currencyInfo.displayCurrency
+        : "PLN";
+    const divisor = currency === "PLN" ? 1 : currencyInfo!.exchangeRate;
+    const minCost = (range.minUsageM3 * pricePerUnitPln) / divisor;
+    const maxCost = (range.maxUsageM3 * pricePerUnitPln) / divisor;
+
+    return `${formatNumber(minCost)}-${formatNumber(maxCost)} ${currency}`;
+}
+
+export function formatWaterRate(pricePerUnitPln: number): string {
+    return `${formatNumber(pricePerUnitPln)} PLN/${M3_LABEL}`;
+}
+
+export function getRatePerLiterTooltip(pricePerUnitPln: number): string {
+    return `1 ${M3_LABEL} = 1000 L, so ${formatNumber(pricePerUnitPln)} PLN/${M3_LABEL} = ${formatNumber(pricePerUnitPln / 1000, 3)} PLN/L.`;
+}
+
+function formatNumber(value: number, maximumFractionDigits = 2): string {
+    return new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: 0,
+        maximumFractionDigits,
+    }).format(value);
+}

--- a/frontend/src/utils/waterBilling.ts
+++ b/frontend/src/utils/waterBilling.ts
@@ -60,17 +60,29 @@ export function formatMoneyRange(
     return `${formatNumber(minCost)}-${formatNumber(maxCost)} ${currency}`;
 }
 
-export function formatWaterRate(pricePerUnitPln: number): string {
-    return `${formatNumber(pricePerUnitPln)} PLN/${M3_LABEL}`;
+export function formatWaterRate(pricePerUnitPln: number, currencyInfo?: CurrencyInfo): string {
+    const plnRate = `${formatNumber(pricePerUnitPln, 2, 2)} PLN/${M3_LABEL}`;
+
+    if (!currencyInfo || currencyInfo.displayCurrency === "PLN" || currencyInfo.exchangeRate <= 0) {
+        return plnRate;
+    }
+
+    const convertedRate = pricePerUnitPln / currencyInfo.exchangeRate;
+    return `${plnRate} (~${formatNumber(convertedRate, 2, 2)} ${currencyInfo.displayCurrency}/${M3_LABEL})`;
 }
 
-export function getRatePerLiterTooltip(pricePerUnitPln: number): string {
-    return `1 ${M3_LABEL} = 1000 L, so ${formatNumber(pricePerUnitPln)} PLN/${M3_LABEL} = ${formatNumber(pricePerUnitPln / 1000, 3)} PLN/L.`;
+export function getRatePerLiterTooltip(pricePerUnitPln: number, currencyInfo?: CurrencyInfo): string {
+    if (!currencyInfo || currencyInfo.displayCurrency === "PLN" || currencyInfo.exchangeRate <= 0) {
+        return `1 ${M3_LABEL} = 1000 L, so ${formatNumber(pricePerUnitPln, 2, 2)} PLN/${M3_LABEL} = ${formatNumber(pricePerUnitPln / 1000, 4, 4)} PLN/L.`;
+    }
+
+    const convertedRate = pricePerUnitPln / currencyInfo.exchangeRate;
+    return `1 ${M3_LABEL} = 1000 L. ${formatNumber(pricePerUnitPln, 2, 2)} PLN/${M3_LABEL} \u2248 ${formatNumber(convertedRate, 2, 2)} ${currencyInfo.displayCurrency}/${M3_LABEL}, so \u2248 ${formatNumber(convertedRate / 1000, 4, 4)} ${currencyInfo.displayCurrency}/L.`;
 }
 
-function formatNumber(value: number, maximumFractionDigits = 2): string {
+function formatNumber(value: number, maximumFractionDigits = 2, minimumFractionDigits = 0): string {
     return new Intl.NumberFormat("en-US", {
-        minimumFractionDigits: 0,
+        minimumFractionDigits,
         maximumFractionDigits,
     }).format(value);
 }


### PR DESCRIPTION
## Summary

Adds a frontend-only water billing transparency section for checkout and reservation details.

The checkout now separates the accommodation total from post-stay water settlement. Guests can see the configured water rate, estimated usage range, estimated cost range, and a short disclaimer that the final amount may change based on meter readings. A required frontend-only acknowledgement checkbox was added before payment.

## Linked issue

Closes #160

## Scope of changes

- Added `UnitSettlementItem` frontend type and `getUnitSettlementItems` API support, including demo-mode fallback.
- Added water billing helpers for tariff lookup, stay length calculation, usage estimation, currency-aware rate/cost formatting, and per-liter explanation.
- Added checkout UI for:
  - accommodation total label,
  - water rate,
  - estimated water usage,
  - estimated water cost,
  - styled rate explanation panel,
  - required water billing acknowledgement checkbox.
- Added reservation details reminder with water billing rate, usage and cost estimate when data is available.
- Kept water billing estimate separate from Stripe, reservation totals and backend billing logic.

## Technical notes

- Scope is limited to WATER only.
- Water tariff is read from existing unit settlement items using `WATER / PER_USAGE / M3`.
- Water usage estimate follows the existing billing heuristic:
  - `expectedUsageM3 = capacity * nights * 0.1`
  - `minUsageM3 = expectedUsageM3 * 0.2`
  - `maxUsageM3 = expectedUsageM3 * 3.0`
- Currency conversion uses the existing app convention:
  - `convertedValue = plnValue / exchangeRate`
- The acknowledgement checkbox is frontend-only and is not persisted in the backend.

## Testing status

- [x] Tested locally
- [x] Existing tests pass
- [x] Frontend Docker rebuild verified with `docker compose -f infra/compose/docker-compose.yml up -d --build --no-deps frontend`

## Manual verification

- Verified checkout displays accommodation total separately from water billing.
- Verified water rate, estimated usage and estimated cost are displayed.
- Verified tooltip/info panel is readable and does not overlap price summary rows.
- Verified tooltip/info panel opens from the `?` icon and remains usable after opening.
- Verified required water billing checkbox blocks payment until accepted.
- Verified reservation details page shows water billing information/reminder.
- Verified water estimate does not affect reservation total or payment amount.

## Checklist

- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Ready for review