### PR TITLE
Update ReportExportButtons.tsx

### DIFF
--- a/frontend/src/components/ReportExportButtons.tsx
+++ b/frontend/src/components/ReportExportButtons.tsx
@@ -272,7 +272,7 @@ export default function ReportExportButtons({
       pdf.setFont("Helvetica", "bold");
       pdf.setFontSize(8);
       pdf.setTextColor(255, 255, 255);
-      pdf.text("Lp.", 18.5, 103.5, { align: "center" });
+      pdf.text("No.", 18.5, 103.5, { align: "center" });
       pdf.text("Description of Service", 24, 103.5);
       pdf.text("Qty", 95, 103.5, { align: "center" });
       pdf.text("Unit Price (Net)", 127.5, 103.5, { align: "right" });
@@ -536,7 +536,7 @@ export default function ReportExportButtons({
       pdf.setFont("Helvetica", "bold");
       pdf.setFontSize(8);
       pdf.setTextColor(255, 255, 255);
-      pdf.text("Lp.", 18, 71.5, { align: "center" });
+      pdf.text("No.", 18, 71.5, { align: "center" });
       pdf.text("Guest Name", 23, 71.5);
       pdf.text("Unit Name", 53, 71.5);
       pdf.text("Check-in", 83, 71.5);
@@ -573,7 +573,7 @@ export default function ReportExportButtons({
           pdf.setFont("Helvetica", "bold");
           pdf.setFontSize(8);
           pdf.setTextColor(255, 255, 255);
-          pdf.text("Lp.", 18, 37.5, { align: "center" });
+          pdf.text("No.", 18, 37.5, { align: "center" });
           pdf.text("Guest Name", 23, 37.5);
           pdf.text("Unit Name", 53, 37.5);
           pdf.text("Check-in", 83, 37.5);


### PR DESCRIPTION
## Summary
This pull request fixes a localization oversight in the system's generated PDF reports. The Polish abbreviation `"Lp."` (liczba porządkowa) has been replaced with the standard English equivalent `"No."` across all PDF templates.

## Linked issue
Closes #162

## Scope of changes
Describe the main changes included in this pull request.

- Modified [ReportExportButtons.tsx](file:///c:/Users/alicj/Documents/GitHub/KWATERA/frontend/src/components/ReportExportButtons.tsx) to replace `"Lp."` with `"No."` in the column headers for both the Itemized Billing Entries and the Detailed Reservations Log tables.
- Verified that the alignment (centered) and width of the columns (6mm and 7mm) are appropriate for the new 3-character label, ensuring that the overall grid layout remains intact.

## Testing status
Describe how this was verified.

- [x] Tested locally
- [x] Existing tests pass

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] Ready for review