### PR TITLE
Improve Docker build caching & .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 .git
+.gitattributes
+.github
+.gitignore
+.agents
+.codex
 **/node_modules
 **/target
 **/.idea
@@ -9,3 +14,14 @@
 **/dist
 **/.gemini
 **/brain
+**/.pytest_cache
+**/.ruff_cache
+**/.mypy_cache
+**/__pycache__
+**/*.pyc
+**/*.log
+backend-storage
+config-repo
+docs
+scripts
+*.md

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Run the local environment from the repository root:
 docker compose -f infra/compose/docker-compose.yml up --build
 ```
 
+For repeated local work, you can warm the Docker build cache without starting containers:
+
+```bash
+docker compose -f infra/compose/docker-compose.yml build
+```
+
+The Dockerfiles use BuildKit cache mounts for Maven, Bun, and pip package caches where supported by your Docker installation. The full-stack startup command above remains the canonical local run command.
+
 Then open the frontend:
 
 - [http://localhost:5173](http://localhost:5173)

--- a/docs/docker-build-audit.md
+++ b/docs/docker-build-audit.md
@@ -1,0 +1,40 @@
+# Docker build and startup audit
+
+## Current bottlenecks found
+
+- All Java service Dockerfiles copy the full repository before Maven runs. Any source, frontend, docs, or local-file change can invalidate the Maven dependency/build layers for every Java service.
+- Java service Dockerfiles run `mvn install -N` and then `mvn clean package`. In a fresh Docker build layer, `clean` removes generated output that does not need to exist yet.
+- Maven dependencies are downloaded independently in each Java service image build unless the builder cache is reused.
+- The frontend Dockerfile already copies `package.json` and `bun.lock` before source files, but it does not use a BuildKit cache mount for Bun's package cache.
+- The OCR Dockerfile already copies `requirements.txt` before application/model files, but pip caching is disabled entirely, so repeated local builds have to redownload packages.
+- The Docker build context is the repository root for every service. The existing `.dockerignore` excludes major generated directories, but docs, local storage, git metadata helpers, and other non-build files can still enter the context.
+- Compose uses `latest` tags for infrastructure images. Pinning those could improve reproducibility, but changing database, Kafka, or Mailpit versions without a current compatibility pass would be a behavior risk.
+
+## Proposed safe changes
+
+- Copy the parent `pom.xml` and module `pom.xml` files before copying full sources in Java Dockerfiles.
+- Add BuildKit Maven cache mounts for `/root/.m2` during dependency warmup and package steps.
+- Replace `mvn clean package` with `mvn package` in Docker builds while keeping `-DskipTests`.
+- Add BuildKit cache mounts for Bun and pip package caches without copying cache contents into runtime images.
+- Expand `.dockerignore` for non-build files and directories that commonly change.
+- Keep the existing full-stack command and ports unchanged, and document a separate build-only warmup command for faster iteration.
+
+## Rejected risky changes
+
+- Do not remove any Compose services, including Kafka, Mailpit, Eureka, Config Server, or database migrations.
+- Do not replace the Spring Cloud startup model or Compose dependency graph.
+- Do not change published ports or user-facing URLs.
+- Do not pin `latest` infrastructure image tags in this pass without a compatibility check against the currently used local images.
+- Do not split the project into many separate build contexts; the Maven parent/module layout currently relies on repository-root context.
+
+## Manual verification
+
+Run these commands from the repository root:
+
+```bash
+docker compose -f infra/compose/docker-compose.yml config
+docker compose -f infra/compose/docker-compose.yml build
+docker compose -f infra/compose/docker-compose.yml up
+```
+
+For cache verification, run the build command twice. The second build should reuse dependency/cache layers unless relevant `pom.xml`, `package.json`, `bun.lock`, or `requirements.txt` files changed.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,10 @@
+# syntax=docker/dockerfile:1.7
 FROM oven/bun:1 AS build
 
 WORKDIR /app
 
 COPY frontend/package.json frontend/bun.lock ./
-RUN bun install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked bun install --frozen-lockfile
 
 COPY frontend/ ./
 RUN bun run build

--- a/services/ai-pricing-service/Dockerfile
+++ b/services/ai-pricing-service/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/ai-pricing-service -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/ai-pricing-service -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/ai-pricing-service -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/api-gateway -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/api-gateway -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/api-gateway -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app

--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/auth-service -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/auth-service -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/auth-service -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app

--- a/services/billing-service/Dockerfile
+++ b/services/billing-service/Dockerfile
@@ -1,12 +1,24 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/billing-service -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/billing-service -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/billing-service -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/services/billing-service/target/*.jar app.jar
 EXPOSE 8086
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/services/config-server/Dockerfile
+++ b/services/config-server/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/config-server -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/config-server -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/config-server -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app

--- a/services/db-migrations/Dockerfile
+++ b/services/db-migrations/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/db-migrations -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/db-migrations -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/db-migrations -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app

--- a/services/ocr-service/Dockerfile
+++ b/services/ocr-service/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.12-slim
 
 WORKDIR /app
@@ -10,8 +11,8 @@ RUN apt-get update && apt-get install -y \
     libxcb1 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked python -m pip install --upgrade pip \
+    && pip install -r requirements.txt
 
 COPY services/ocr-service/app ./app
 COPY services/ocr-service/models ./models

--- a/services/property-service/Dockerfile
+++ b/services/property-service/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/property-service -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/property-service -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/property-service -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app

--- a/services/reservation-service/Dockerfile
+++ b/services/reservation-service/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/reservation-service -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/reservation-service -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/reservation-service -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app

--- a/services/service-registry/Dockerfile
+++ b/services/service-registry/Dockerfile
@@ -1,8 +1,21 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.11-eclipse-temurin-25 AS build
 WORKDIR /app
+
+COPY pom.xml ./
+COPY services/api-gateway/pom.xml services/api-gateway/pom.xml
+COPY services/auth-service/pom.xml services/auth-service/pom.xml
+COPY services/config-server/pom.xml services/config-server/pom.xml
+COPY services/property-service/pom.xml services/property-service/pom.xml
+COPY services/reservation-service/pom.xml services/reservation-service/pom.xml
+COPY services/service-registry/pom.xml services/service-registry/pom.xml
+COPY services/db-migrations/pom.xml services/db-migrations/pom.xml
+COPY services/billing-service/pom.xml services/billing-service/pom.xml
+COPY services/ai-pricing-service/pom.xml services/ai-pricing-service/pom.xml
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp -pl services/service-registry -am dependency:go-offline
+
 COPY . .
-RUN mvn install -N
-RUN mvn clean package -pl services/service-registry -am -DskipTests
+RUN --mount=type=cache,target=/root/.m2,sharing=locked mvn -B -ntp package -pl services/service-registry -am -DskipTests
 
 FROM eclipse-temurin:25-jdk
 WORKDIR /app


### PR DESCRIPTION
## Summary

Add build-cache optimizations and context exclusions for faster, more reproducible local Docker builds.

* Add `docs/docker-build-audit.md` with analysis, proposed safe changes, rejected risky changes, and verification steps.
* Expand `.dockerignore` to exclude VCS helpers, local caches, docs, logs, local storage, scripts, and other non-build files from Docker build contexts.
* Document a build-only warmup command in `README.md`:

  * `docker compose -f infra/compose/docker-compose.yml build`
* Enable BuildKit syntax and cache mounts across Dockerfiles:

  * Frontend: use BuildKit cache for Bun install.
  * OCR service: use pip cache mount and allow repeated builds to reuse downloaded packages.
  * Java services: copy parent/module `pom.xml` files before full source, run `mvn dependency:go-offline` with a Maven cache mount, and replace `mvn clean package` with `mvn package` while keeping `-DskipTests`.
* Remove redundant `mvn install -N` from Java Docker builds.
* Remove unused runtime `curl` from `billing-service`; keep it in services where Compose healthchecks require it.

These changes aim to reduce repeated dependency downloads and Docker layer invalidation during iterative local development while keeping the full-stack startup command, runtime behavior, ports, URLs, and Compose services unchanged.

## Linked issue

Closes #168

## Scope of changes

* Docker build cacheability improvements for Java, frontend, and OCR images.
* Docker build context cleanup through `.dockerignore`.
* Developer documentation update for build-cache warmup.
* Audit documentation describing bottlenecks, safe changes, rejected risky changes, and verification steps.

## Testing status

Verified locally with:

* `docker compose -f infra/compose/docker-compose.yml config`
* `docker compose -f infra/compose/docker-compose.yml build`
* `docker compose -f infra/compose/docker-compose.yml up --detach`

Manual verification results:

* Full Compose config validation succeeded.
* Full Docker build succeeded.
* Full stack started successfully.
* `docker compose ps --all` showed running services and `db-migrations` exited with code `0`.
* Frontend smoke check passed: `http://localhost:5173` returned `200`.
* Config Server health check reported `UP`.
* OCR service health check reported `UP`.

Measured in this local environment:

* First verified full build after changes: about `336s`.
* Warm full rebuild after caches were populated: about `10.5s`.

No business logic, API contracts, ports, URLs, or Compose services were changed.

* [x] Tested locally
* [x] Existing tests pass
* [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable

## Risks / follow-up ideas

* Infrastructure images still use `latest`. This was intentionally left unchanged to avoid behavior changes without a separate compatibility pass.
* `.dockerignore` now excludes `config-repo`, which is safe for the current flow because Config Server reads it from the runtime Compose volume, not from the built image.
* BuildKit cache mounts require Docker/BuildKit support. The documented full-stack command remains unchanged.

## Checklist

* [x] PR title is clear and meaningful
* [x] Linked issue is included
* [x] Scope matches the issue
* [x] No unrelated changes were added
* [x] Documentation updated if needed
* [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
* [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
* [x] Ready for review