### PR TITLE
Polish filter reservations by date range in the administration panel

### DIFF
--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -145,16 +145,26 @@ export async function getSystemEvents(query: SystemEventsQuery = {}): Promise<Sy
     return res.json();
 }
 
-export async function getAdminReservations(status?: string) {
+export async function getAdminReservations(status?: string, startDate?: string, endDate?: string) {
     if (IS_DEMO_MODE) {
-        return status
-            ? demoAdminReservations.filter((reservation) => reservation.status === status)
-            : demoAdminReservations;
+        let filtered = demoAdminReservations;
+        if (status) {
+            filtered = filtered.filter((reservation) => reservation.status === status);
+        }
+        if (startDate && endDate) {
+            filtered = filtered.filter((reservation) => reservation.startDate <= endDate && reservation.endDate >= startDate);
+        }
+        return filtered;
     }
 
     const token = localStorage.getItem("token");
-    const url = status
-        ? `${GATEWAY_BASE_URL}/api/v1/admin/reservations?status=${status}`
+    const params = new URLSearchParams();
+    if (status) params.append("status", status);
+    if (startDate) params.append("startDate", startDate);
+    if (endDate) params.append("endDate", endDate);
+    const queryString = params.toString();
+    const url = queryString
+        ? `${GATEWAY_BASE_URL}/api/v1/admin/reservations?${queryString}`
         : `${GATEWAY_BASE_URL}/api/v1/admin/reservations`;
 
     const res = await fetch(url, {

--- a/frontend/src/components/AdminReservationList.tsx
+++ b/frontend/src/components/AdminReservationList.tsx
@@ -4,6 +4,18 @@ import { getAdminReservations, updateAdminReservationStatus } from "../api/admin
 import { getSettlementDetails } from '../api/settlementApi';
 import { getReservationDetails } from "../api/reservationApi";
 import { ChevronDown } from 'lucide-react';
+import SharedDatePicker from "./SharedDatePicker";
+import { format } from "date-fns";
+
+const parseDateString = (str: string): Date | null => {
+    if (!str) return null;
+    const parts = str.split("-");
+    if (parts.length !== 3) return null;
+    const year = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10) - 1;
+    const day = parseInt(parts[2], 10);
+    return new Date(year, month, day);
+};
 
 interface ReservationOverview {
     id: string;
@@ -17,12 +29,14 @@ interface ReservationOverview {
 export default function AdminReservationList() {
     const [reservations, setReservations] = useState<ReservationOverview[]>([]);
     const [statusFilter, setStatusFilter] = useState<string>("");
+    const [startDate, setStartDate] = useState<string>("");
+    const [endDate, setEndDate] = useState<string>("");
     const [message, setMessage] = useState<{ text: string, type: 'success' | 'error' } | null>(null);
     const [settlementIds, setSettlementIds] = useState<Record<string, string>>({});
     const [unitIds, setUnitIds] = useState<Record<string, string>>({});
 
     const fetchReservations = useCallback(() => {
-        getAdminReservations(statusFilter || undefined)
+        getAdminReservations(statusFilter || undefined, startDate || undefined, endDate || undefined)
             .then((data) => {
                 setReservations(data);
                 data.forEach(async (res: ReservationOverview) => {
@@ -41,7 +55,7 @@ export default function AdminReservationList() {
                 });
             })
             .catch((err) => console.error(err));
-    }, [statusFilter]);
+    }, [statusFilter, startDate, endDate]);
 
     useEffect(() => {
         fetchReservations();
@@ -108,37 +122,82 @@ export default function AdminReservationList() {
                 </div>
             )}
 
-            {/* Compact, Inline Toolbar Section */}
-            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 bg-[#F7F7F7] border border-gray-100 rounded-xl p-4">
+            {/* Toolbar Section: Status and Date Range Filters */}
+            <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 bg-[#F7F7F7] border border-[#DACDCA] rounded-xl p-4 shadow-sm">
                 <div className="text-sm font-medium text-[#7A7A7A]">
                     Showing <span className="font-bold text-[#1A1A1A]">{filteredReservations.length}</span> reservation{filteredReservations.length === 1 ? '' : 's'}
                 </div>
-                <div className="flex items-center gap-2 w-full sm:w-auto">
-                    <span className="text-sm font-medium text-gray-500 mr-2 shrink-0">Filter by Status:</span>
-                    <div className="relative w-full sm:w-44">
-                        <select
-                            className="appearance-none block w-full bg-white border border-gray-300 rounded-md py-2 pl-3 pr-10 text-sm text-[#1A1A1A] font-semibold focus:outline-none focus:ring-2 focus:ring-brand-primary focus:border-brand-primary transition-all shadow-sm cursor-pointer"
-                            value={statusFilter}
-                            onChange={(e) => setStatusFilter(e.target.value)}
-                        >
-                            <option value="">All Statuses</option>
-                            <option value="PENDING">Pending</option>
-                            <option value="CONFIRMED">Confirmed</option>
-                            <option value="CANCELLED">Cancelled</option>
-                            <option value="COMPLETED">Completed</option>
-                        </select>
-                        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-                            <ChevronDown className="h-4 w-4 text-[#7A7A7A]" />
+                <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4 w-full md:w-auto">
+                    {/* Status Filter */}
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-gray-500 shrink-0">Status:</span>
+                        <div className="relative w-full sm:w-36">
+                            <select
+                                className="appearance-none block w-full bg-white border border-[#DACDCA] rounded-lg py-2 pl-3 pr-10 text-sm text-[#1A1A1A] font-semibold focus:outline-none focus:ring-2 focus:ring-[#42211D]/20 focus:border-[#42211D] transition-all shadow-sm cursor-pointer"
+                                value={statusFilter}
+                                onChange={(e) => setStatusFilter(e.target.value)}
+                            >
+                                <option value="">All Statuses</option>
+                                <option value="PENDING">Pending</option>
+                                <option value="CONFIRMED">Confirmed</option>
+                                <option value="CANCELLED">Cancelled</option>
+                                <option value="COMPLETED">Completed</option>
+                            </select>
+                            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                                <ChevronDown className="h-4 w-4 text-[#7A7A7A]" />
+                            </div>
                         </div>
+                        {statusFilter && (
+                            <button
+                                onClick={() => setStatusFilter("")}
+                                className="text-sm font-medium text-gray-500 hover:text-[#42211D] transition-colors shrink-0 cursor-pointer"
+                            >
+                                Clear
+                            </button>
+                        )}
                     </div>
-                    {statusFilter && (
-                        <button
-                            onClick={() => setStatusFilter("")}
-                            className="text-sm font-medium text-gray-500 hover:text-brand-main transition-colors shrink-0 cursor-pointer"
-                        >
-                            Clear
-                        </button>
-                    )}
+
+                    {/* Date Filters */}
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-gray-500 shrink-0">Dates:</span>
+                        <div className="flex items-center gap-2 bg-white border border-[#DACDCA] rounded-lg p-1.5 shadow-sm">
+                            <SharedDatePicker
+                                selected={parseDateString(startDate)}
+                                onChange={(date) => setStartDate(date ? format(date, "yyyy-MM-dd") : "")}
+                                selectsStart
+                                startDate={parseDateString(startDate)}
+                                endDate={parseDateString(endDate)}
+                                allowPastDates={true}
+                                placeholderText="Start Date"
+                                className="bg-transparent text-sm font-semibold text-[#1A1A1A] outline-none cursor-pointer w-24 text-center"
+                                wrapperClassName="w-auto"
+                            />
+                            <span className="text-gray-400 font-medium text-xs">to</span>
+                            <SharedDatePicker
+                                selected={parseDateString(endDate)}
+                                onChange={(date) => setEndDate(date ? format(date, "yyyy-MM-dd") : "")}
+                                selectsEnd
+                                startDate={parseDateString(startDate)}
+                                endDate={parseDateString(endDate)}
+                                minDate={parseDateString(startDate)}
+                                allowPastDates={true}
+                                placeholderText="End Date"
+                                className="bg-transparent text-sm font-semibold text-[#1A1A1A] outline-none cursor-pointer w-24 text-center"
+                                wrapperClassName="w-auto"
+                            />
+                        </div>
+                        {(startDate || endDate) && (
+                            <button
+                                onClick={() => {
+                                    setStartDate("");
+                                    setEndDate("");
+                                }}
+                                className="text-sm font-medium text-gray-500 hover:text-[#42211D] transition-colors shrink-0 cursor-pointer"
+                            >
+                                Clear Dates
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
 

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminReservationController.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminReservationController.java
@@ -4,9 +4,11 @@ import io.github.kwatera_project.kwatera.reservation_service.dto.ReservationOver
 import io.github.kwatera_project.kwatera.reservation_service.dto.ReservationStatusUpdateRequest;
 import io.github.kwatera_project.kwatera.reservation_service.model.ReservationStatus;
 import io.github.kwatera_project.kwatera.reservation_service.service.AdminReservationService;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -24,6 +26,12 @@ public class AdminReservationController {
   @GetMapping
   public List<ReservationOverviewDto> getReservations(
       @RequestParam(name = "status", required = false) ReservationStatus status,
+      @RequestParam(name = "startDate", required = false)
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startDate,
+      @RequestParam(name = "endDate", required = false)
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate endDate,
       Authentication authentication) {
 
     if (authentication == null || !authentication.isAuthenticated()) {
@@ -47,7 +55,8 @@ public class AdminReservationController {
         authentication.getAuthorities().stream()
             .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
 
-    return adminReservationService.getReservationsOverview(ownerId, status, isAdmin);
+    return adminReservationService.getReservationsOverview(
+        ownerId, status, isAdmin, startDate, endDate);
   }
 
   @PatchMapping("/{reservationId}/status")

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/repository/ReservationRepository.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/repository/ReservationRepository.java
@@ -59,4 +59,30 @@ public interface ReservationRepository extends JpaRepository<Reservation, UUID> 
       ReservationStatus status, java.time.Instant threshold);
 
   List<Reservation> findByStartDateAndStatus(LocalDate startDate, ReservationStatus status);
+
+  @Query("SELECT r FROM Reservation r WHERE r.startDate <= :endDate AND r.endDate >= :startDate")
+  List<Reservation> findReservationsOverlapping(
+      @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+  @Query(
+      "SELECT r FROM Reservation r WHERE r.status = :status AND r.startDate <= :endDate AND r.endDate >= :startDate")
+  List<Reservation> findReservationsOverlappingWithStatus(
+      @Param("status") ReservationStatus status,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate);
+
+  @Query(
+      "SELECT r FROM Reservation r WHERE r.unitId IN :unitIds AND r.startDate <= :endDate AND r.endDate >= :startDate")
+  List<Reservation> findReservationsOverlappingForUnits(
+      @Param("unitIds") List<UUID> unitIds,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate);
+
+  @Query(
+      "SELECT r FROM Reservation r WHERE r.unitId IN :unitIds AND r.status = :status AND r.startDate <= :endDate AND r.endDate >= :startDate")
+  List<Reservation> findReservationsOverlappingForUnitsWithStatus(
+      @Param("unitIds") List<UUID> unitIds,
+      @Param("status") ReservationStatus status,
+      @Param("startDate") LocalDate startDate,
+      @Param("endDate") LocalDate endDate);
 }

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
@@ -63,7 +63,8 @@ public class AdminReservationService {
       LocalDate endDate) {
 
     if (isAdmin) {
-      List<Reservation> reservations = getAdminReservationsFromRepository(status, startDate, endDate);
+      List<Reservation> reservations =
+          getAdminReservationsFromRepository(status, startDate, endDate);
       return reservations.stream().map(this::mapToOverviewDto).toList();
     }
 
@@ -78,7 +79,8 @@ public class AdminReservationService {
         return Collections.emptyList();
       }
 
-      List<Reservation> reservations = getOwnerReservationsFromRepository(ownerUnitIds, status, startDate, endDate);
+      List<Reservation> reservations =
+          getOwnerReservationsFromRepository(ownerUnitIds, status, startDate, endDate);
       return reservations.stream().map(this::mapToOverviewDto).toList();
 
     } catch (Exception e) {

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
@@ -8,6 +8,7 @@ import io.github.kwatera_project.kwatera.reservation_service.model.ReservationSt
 import io.github.kwatera_project.kwatera.reservation_service.model.ReservationStatusHistory;
 import io.github.kwatera_project.kwatera.reservation_service.repository.ReservationRepository;
 import io.github.kwatera_project.kwatera.reservation_service.repository.ReservationStatusHistoryRepository;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,13 +56,26 @@ public class AdminReservationService {
   }
 
   public List<ReservationOverviewDto> getReservationsOverview(
-      UUID ownerId, ReservationStatus status, boolean isAdmin) {
+      UUID ownerId,
+      ReservationStatus status,
+      boolean isAdmin,
+      LocalDate startDate,
+      LocalDate endDate) {
 
     if (isAdmin) {
-      List<Reservation> reservations =
-          (status != null)
-              ? reservationRepository.findByStatus(status)
-              : reservationRepository.findAll();
+      List<Reservation> reservations;
+      if (startDate != null && endDate != null) {
+        reservations =
+            (status != null)
+                ? reservationRepository.findReservationsOverlappingWithStatus(
+                    status, startDate, endDate)
+                : reservationRepository.findReservationsOverlapping(startDate, endDate);
+      } else {
+        reservations =
+            (status != null)
+                ? reservationRepository.findByStatus(status)
+                : reservationRepository.findAll();
+      }
 
       return reservations.stream().map(this::mapToOverviewDto).toList();
     }
@@ -77,10 +91,20 @@ public class AdminReservationService {
         return Collections.emptyList();
       }
 
-      List<Reservation> reservations =
-          (status != null)
-              ? reservationRepository.findByUnitIdInAndStatus(ownerUnitIds, status)
-              : reservationRepository.findByUnitIdIn(ownerUnitIds);
+      List<Reservation> reservations;
+      if (startDate != null && endDate != null) {
+        reservations =
+            (status != null)
+                ? reservationRepository.findReservationsOverlappingForUnitsWithStatus(
+                    ownerUnitIds, status, startDate, endDate)
+                : reservationRepository.findReservationsOverlappingForUnits(
+                    ownerUnitIds, startDate, endDate);
+      } else {
+        reservations =
+            (status != null)
+                ? reservationRepository.findByUnitIdInAndStatus(ownerUnitIds, status)
+                : reservationRepository.findByUnitIdIn(ownerUnitIds);
+      }
 
       return reservations.stream().map(this::mapToOverviewDto).toList();
 

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationService.java
@@ -63,20 +63,7 @@ public class AdminReservationService {
       LocalDate endDate) {
 
     if (isAdmin) {
-      List<Reservation> reservations;
-      if (startDate != null && endDate != null) {
-        reservations =
-            (status != null)
-                ? reservationRepository.findReservationsOverlappingWithStatus(
-                    status, startDate, endDate)
-                : reservationRepository.findReservationsOverlapping(startDate, endDate);
-      } else {
-        reservations =
-            (status != null)
-                ? reservationRepository.findByStatus(status)
-                : reservationRepository.findAll();
-      }
-
+      List<Reservation> reservations = getAdminReservationsFromRepository(status, startDate, endDate);
       return reservations.stream().map(this::mapToOverviewDto).toList();
     }
 
@@ -91,27 +78,39 @@ public class AdminReservationService {
         return Collections.emptyList();
       }
 
-      List<Reservation> reservations;
-      if (startDate != null && endDate != null) {
-        reservations =
-            (status != null)
-                ? reservationRepository.findReservationsOverlappingForUnitsWithStatus(
-                    ownerUnitIds, status, startDate, endDate)
-                : reservationRepository.findReservationsOverlappingForUnits(
-                    ownerUnitIds, startDate, endDate);
-      } else {
-        reservations =
-            (status != null)
-                ? reservationRepository.findByUnitIdInAndStatus(ownerUnitIds, status)
-                : reservationRepository.findByUnitIdIn(ownerUnitIds);
-      }
-
+      List<Reservation> reservations = getOwnerReservationsFromRepository(ownerUnitIds, status, startDate, endDate);
       return reservations.stream().map(this::mapToOverviewDto).toList();
 
     } catch (Exception e) {
       log.error("Error connection with property-service", e);
       return Collections.emptyList();
     }
+  }
+
+  private List<Reservation> getAdminReservationsFromRepository(
+      ReservationStatus status, LocalDate startDate, LocalDate endDate) {
+    if (startDate != null && endDate != null) {
+      return (status != null)
+          ? reservationRepository.findReservationsOverlappingWithStatus(status, startDate, endDate)
+          : reservationRepository.findReservationsOverlapping(startDate, endDate);
+    }
+    return (status != null)
+        ? reservationRepository.findByStatus(status)
+        : reservationRepository.findAll();
+  }
+
+  private List<Reservation> getOwnerReservationsFromRepository(
+      List<UUID> ownerUnitIds, ReservationStatus status, LocalDate startDate, LocalDate endDate) {
+    if (startDate != null && endDate != null) {
+      return (status != null)
+          ? reservationRepository.findReservationsOverlappingForUnitsWithStatus(
+              ownerUnitIds, status, startDate, endDate)
+          : reservationRepository.findReservationsOverlappingForUnits(
+              ownerUnitIds, startDate, endDate);
+    }
+    return (status != null)
+        ? reservationRepository.findByUnitIdInAndStatus(ownerUnitIds, status)
+        : reservationRepository.findByUnitIdIn(ownerUnitIds);
   }
 
   public ReservationOverviewDto updateReservationStatus(

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminReservationControllerTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminReservationControllerTest.java
@@ -57,7 +57,7 @@ class AdminReservationControllerTest {
   void shouldReturnReservations_whenValidAdminTokenProvided() throws Exception {
     UUID ownerId = UUID.randomUUID();
     when(adminReservationService.getReservationsOverview(
-            ownerId, ReservationStatus.CONFIRMED, true))
+            ownerId, ReservationStatus.CONFIRMED, true, null, null))
         .thenReturn(Collections.emptyList());
 
     mockMvc
@@ -68,7 +68,7 @@ class AdminReservationControllerTest {
         .andExpect(status().isOk());
 
     verify(adminReservationService)
-        .getReservationsOverview(ownerId, ReservationStatus.CONFIRMED, true);
+        .getReservationsOverview(ownerId, ReservationStatus.CONFIRMED, true, null, null);
   }
 
   @Test
@@ -163,7 +163,7 @@ class AdminReservationControllerTest {
     org.springframework.web.server.ResponseStatusException ex =
         assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
-            () -> adminReservationController.getReservations(null, null));
+            () -> adminReservationController.getReservations(null, null, null, null));
     org.junit.jupiter.api.Assertions.assertEquals(
         org.springframework.http.HttpStatus.UNAUTHORIZED, ex.getStatusCode());
   }
@@ -176,7 +176,7 @@ class AdminReservationControllerTest {
     org.springframework.web.server.ResponseStatusException ex =
         assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
-            () -> adminReservationController.getReservations(null, auth));
+            () -> adminReservationController.getReservations(null, null, null, auth));
     org.junit.jupiter.api.Assertions.assertEquals(
         org.springframework.http.HttpStatus.UNAUTHORIZED, ex.getStatusCode());
   }
@@ -190,7 +190,7 @@ class AdminReservationControllerTest {
     org.springframework.web.server.ResponseStatusException ex =
         assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
-            () -> adminReservationController.getReservations(null, auth));
+            () -> adminReservationController.getReservations(null, null, null, auth));
     org.junit.jupiter.api.Assertions.assertEquals(
         org.springframework.http.HttpStatus.UNAUTHORIZED, ex.getStatusCode());
   }
@@ -204,7 +204,7 @@ class AdminReservationControllerTest {
     org.springframework.web.server.ResponseStatusException ex =
         org.junit.jupiter.api.Assertions.assertThrows(
             org.springframework.web.server.ResponseStatusException.class,
-            () -> adminReservationController.getReservations(null, auth));
+            () -> adminReservationController.getReservations(null, null, null, auth));
     org.junit.jupiter.api.Assertions.assertEquals(
         org.springframework.http.HttpStatus.UNAUTHORIZED, ex.getStatusCode());
   }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminReservationControllerTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminReservationControllerTest.java
@@ -13,6 +13,7 @@ import io.github.kwatera_project.kwatera.reservation_service.filter.JwtAuthFilte
 import io.github.kwatera_project.kwatera.reservation_service.model.ReservationStatus;
 import io.github.kwatera_project.kwatera.reservation_service.service.AdminReservationService;
 import io.github.kwatera_project.kwatera.reservation_service.service.JwtService;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -69,6 +70,29 @@ class AdminReservationControllerTest {
 
     verify(adminReservationService)
         .getReservationsOverview(ownerId, ReservationStatus.CONFIRMED, true, null, null);
+  }
+
+  @Test
+  void shouldReturnReservationsWithDateRange_whenValidAdminTokenAndDatesProvided()
+      throws Exception {
+    UUID ownerId = UUID.randomUUID();
+    LocalDate startDate = LocalDate.of(2026, 6, 1);
+    LocalDate endDate = LocalDate.of(2026, 6, 10);
+    when(adminReservationService.getReservationsOverview(
+            ownerId, ReservationStatus.CONFIRMED, true, startDate, endDate))
+        .thenReturn(Collections.emptyList());
+
+    mockMvc
+        .perform(
+            get("/api/v1/admin/reservations")
+                .param("status", "CONFIRMED")
+                .param("startDate", "2026-06-01")
+                .param("endDate", "2026-06-10")
+                .with(authentication(buildAuth(ownerId, "ROLE_ADMIN"))))
+        .andExpect(status().isOk());
+
+    verify(adminReservationService)
+        .getReservationsOverview(ownerId, ReservationStatus.CONFIRMED, true, startDate, endDate);
   }
 
   @Test

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
@@ -90,6 +90,36 @@ class AdminReservationServiceTest {
   }
 
   @Test
+  void shouldReturnFilteredReservationsByDateRangeAndStatus_whenUserIsAdminAndDatesAndStatusProvided() {
+    LocalDate startDate = LocalDate.of(2026, 6, 1);
+    LocalDate endDate = LocalDate.of(2026, 6, 10);
+    Reservation reservation = createReservation();
+    when(reservationRepository.findReservationsOverlappingWithStatus(ReservationStatus.CONFIRMED, startDate, endDate))
+        .thenReturn(List.of(reservation));
+
+    List<ReservationOverviewDto> result =
+        adminReservationService.getReservationsOverview(
+            UUID.randomUUID(), ReservationStatus.CONFIRMED, true, startDate, endDate);
+
+    assertEquals(1, result.size());
+    verify(reservationRepository).findReservationsOverlappingWithStatus(ReservationStatus.CONFIRMED, startDate, endDate);
+  }
+
+  @Test
+  void shouldFallbackToAllReservations_whenUserIsAdminAndOnlyStartDateProvided() {
+    LocalDate startDate = LocalDate.of(2026, 6, 1);
+    Reservation reservation = createReservation();
+    when(reservationRepository.findAll()).thenReturn(List.of(reservation));
+
+    List<ReservationOverviewDto> result =
+        adminReservationService.getReservationsOverview(
+            UUID.randomUUID(), null, true, startDate, null);
+
+    assertEquals(1, result.size());
+    verify(reservationRepository).findAll();
+  }
+
+  @Test
   void shouldUpdateStatus_whenAdminChangesAnyReservation() {
     UUID resId = UUID.randomUUID();
     UUID adminId = UUID.randomUUID();
@@ -261,6 +291,48 @@ class AdminReservationServiceTest {
             ownerId, ReservationStatus.CONFIRMED, false, null, null);
 
     assertEquals(1, result.size());
+  }
+
+  @Test
+  void shouldReturnFilteredOwnerReservationsByDateRange_whenUserIsOwnerAndDatesProvided() {
+    UUID ownerId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID[] unitIds = {unitId};
+    LocalDate startDate = LocalDate.of(2026, 6, 1);
+    LocalDate endDate = LocalDate.of(2026, 6, 10);
+    Reservation reservation = createReservation();
+
+    when(restTemplate.getForObject(anyString(), eq(UUID[].class))).thenReturn(unitIds);
+    when(reservationRepository.findReservationsOverlappingForUnits(List.of(unitId), startDate, endDate))
+        .thenReturn(List.of(reservation));
+
+    List<ReservationOverviewDto> result =
+        adminReservationService.getReservationsOverview(
+            ownerId, null, false, startDate, endDate);
+
+    assertEquals(1, result.size());
+    verify(reservationRepository).findReservationsOverlappingForUnits(List.of(unitId), startDate, endDate);
+  }
+
+  @Test
+  void shouldReturnFilteredOwnerReservationsByDateRangeAndStatus_whenUserIsOwnerAndDatesAndStatusProvided() {
+    UUID ownerId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID[] unitIds = {unitId};
+    LocalDate startDate = LocalDate.of(2026, 6, 1);
+    LocalDate endDate = LocalDate.of(2026, 6, 10);
+    Reservation reservation = createReservation();
+
+    when(restTemplate.getForObject(anyString(), eq(UUID[].class))).thenReturn(unitIds);
+    when(reservationRepository.findReservationsOverlappingForUnitsWithStatus(List.of(unitId), ReservationStatus.CONFIRMED, startDate, endDate))
+        .thenReturn(List.of(reservation));
+
+    List<ReservationOverviewDto> result =
+        adminReservationService.getReservationsOverview(
+            ownerId, ReservationStatus.CONFIRMED, false, startDate, endDate);
+
+    assertEquals(1, result.size());
+    verify(reservationRepository).findReservationsOverlappingForUnitsWithStatus(List.of(unitId), ReservationStatus.CONFIRMED, startDate, endDate);
   }
 
   @Test

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
@@ -90,11 +90,13 @@ class AdminReservationServiceTest {
   }
 
   @Test
-  void shouldReturnFilteredReservationsByDateRangeAndStatus_whenUserIsAdminAndDatesAndStatusProvided() {
+  void
+      shouldReturnFilteredReservationsByDateRangeAndStatus_whenUserIsAdminAndDatesAndStatusProvided() {
     LocalDate startDate = LocalDate.of(2026, 6, 1);
     LocalDate endDate = LocalDate.of(2026, 6, 10);
     Reservation reservation = createReservation();
-    when(reservationRepository.findReservationsOverlappingWithStatus(ReservationStatus.CONFIRMED, startDate, endDate))
+    when(reservationRepository.findReservationsOverlappingWithStatus(
+            ReservationStatus.CONFIRMED, startDate, endDate))
         .thenReturn(List.of(reservation));
 
     List<ReservationOverviewDto> result =
@@ -102,7 +104,8 @@ class AdminReservationServiceTest {
             UUID.randomUUID(), ReservationStatus.CONFIRMED, true, startDate, endDate);
 
     assertEquals(1, result.size());
-    verify(reservationRepository).findReservationsOverlappingWithStatus(ReservationStatus.CONFIRMED, startDate, endDate);
+    verify(reservationRepository)
+        .findReservationsOverlappingWithStatus(ReservationStatus.CONFIRMED, startDate, endDate);
   }
 
   @Test
@@ -303,19 +306,21 @@ class AdminReservationServiceTest {
     Reservation reservation = createReservation();
 
     when(restTemplate.getForObject(anyString(), eq(UUID[].class))).thenReturn(unitIds);
-    when(reservationRepository.findReservationsOverlappingForUnits(List.of(unitId), startDate, endDate))
+    when(reservationRepository.findReservationsOverlappingForUnits(
+            List.of(unitId), startDate, endDate))
         .thenReturn(List.of(reservation));
 
     List<ReservationOverviewDto> result =
-        adminReservationService.getReservationsOverview(
-            ownerId, null, false, startDate, endDate);
+        adminReservationService.getReservationsOverview(ownerId, null, false, startDate, endDate);
 
     assertEquals(1, result.size());
-    verify(reservationRepository).findReservationsOverlappingForUnits(List.of(unitId), startDate, endDate);
+    verify(reservationRepository)
+        .findReservationsOverlappingForUnits(List.of(unitId), startDate, endDate);
   }
 
   @Test
-  void shouldReturnFilteredOwnerReservationsByDateRangeAndStatus_whenUserIsOwnerAndDatesAndStatusProvided() {
+  void
+      shouldReturnFilteredOwnerReservationsByDateRangeAndStatus_whenUserIsOwnerAndDatesAndStatusProvided() {
     UUID ownerId = UUID.randomUUID();
     UUID unitId = UUID.randomUUID();
     UUID[] unitIds = {unitId};
@@ -324,7 +329,8 @@ class AdminReservationServiceTest {
     Reservation reservation = createReservation();
 
     when(restTemplate.getForObject(anyString(), eq(UUID[].class))).thenReturn(unitIds);
-    when(reservationRepository.findReservationsOverlappingForUnitsWithStatus(List.of(unitId), ReservationStatus.CONFIRMED, startDate, endDate))
+    when(reservationRepository.findReservationsOverlappingForUnitsWithStatus(
+            List.of(unitId), ReservationStatus.CONFIRMED, startDate, endDate))
         .thenReturn(List.of(reservation));
 
     List<ReservationOverviewDto> result =
@@ -332,7 +338,9 @@ class AdminReservationServiceTest {
             ownerId, ReservationStatus.CONFIRMED, false, startDate, endDate);
 
     assertEquals(1, result.size());
-    verify(reservationRepository).findReservationsOverlappingForUnitsWithStatus(List.of(unitId), ReservationStatus.CONFIRMED, startDate, endDate);
+    verify(reservationRepository)
+        .findReservationsOverlappingForUnitsWithStatus(
+            List.of(unitId), ReservationStatus.CONFIRMED, startDate, endDate);
   }
 
   @Test

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/AdminReservationServiceTest.java
@@ -53,7 +53,7 @@ class AdminReservationServiceTest {
     when(reservationRepository.findAll()).thenReturn(List.of(reservation));
 
     List<ReservationOverviewDto> result =
-        adminReservationService.getReservationsOverview(UUID.randomUUID(), null, true);
+        adminReservationService.getReservationsOverview(UUID.randomUUID(), null, true, null, null);
 
     assertEquals(1, result.size());
     verify(reservationRepository).findAll();
@@ -67,10 +67,26 @@ class AdminReservationServiceTest {
 
     List<ReservationOverviewDto> result =
         adminReservationService.getReservationsOverview(
-            UUID.randomUUID(), ReservationStatus.CONFIRMED, true);
+            UUID.randomUUID(), ReservationStatus.CONFIRMED, true, null, null);
 
     assertEquals(1, result.size());
     verify(reservationRepository).findByStatus(ReservationStatus.CONFIRMED);
+  }
+
+  @Test
+  void shouldReturnFilteredReservationsByDateRange_whenUserIsAdminAndDatesProvided() {
+    LocalDate startDate = LocalDate.of(2026, 6, 1);
+    LocalDate endDate = LocalDate.of(2026, 6, 10);
+    Reservation reservation = createReservation();
+    when(reservationRepository.findReservationsOverlapping(startDate, endDate))
+        .thenReturn(List.of(reservation));
+
+    List<ReservationOverviewDto> result =
+        adminReservationService.getReservationsOverview(
+            UUID.randomUUID(), null, true, startDate, endDate);
+
+    assertEquals(1, result.size());
+    verify(reservationRepository).findReservationsOverlapping(startDate, endDate);
   }
 
   @Test
@@ -222,7 +238,7 @@ class AdminReservationServiceTest {
     when(reservationRepository.findByUnitIdIn(List.of(unitId))).thenReturn(List.of(reservation));
 
     List<ReservationOverviewDto> result =
-        adminReservationService.getReservationsOverview(ownerId, null, false);
+        adminReservationService.getReservationsOverview(ownerId, null, false, null, null);
 
     assertEquals(1, result.size());
     verify(reservationRepository).findByUnitIdIn(List.of(unitId));
@@ -242,7 +258,7 @@ class AdminReservationServiceTest {
 
     List<ReservationOverviewDto> result =
         adminReservationService.getReservationsOverview(
-            ownerId, ReservationStatus.CONFIRMED, false);
+            ownerId, ReservationStatus.CONFIRMED, false, null, null);
 
     assertEquals(1, result.size());
   }
@@ -251,7 +267,7 @@ class AdminReservationServiceTest {
   void shouldReturnEmptyList_whenOwnerHasNoUnits() {
     when(restTemplate.getForObject(anyString(), eq(UUID[].class))).thenReturn(new UUID[0]);
     List<ReservationOverviewDto> result =
-        adminReservationService.getReservationsOverview(UUID.randomUUID(), null, false);
+        adminReservationService.getReservationsOverview(UUID.randomUUID(), null, false, null, null);
     assertEquals(0, result.size());
   }
 
@@ -280,7 +296,7 @@ class AdminReservationServiceTest {
     when(restTemplate.getForObject(anyString(), any())).thenThrow(new RuntimeException("API Down"));
 
     List<ReservationOverviewDto> result =
-        adminReservationService.getReservationsOverview(UUID.randomUUID(), null, true);
+        adminReservationService.getReservationsOverview(UUID.randomUUID(), null, true, null, null);
     assertEquals(1, result.size());
     assertEquals(
         "Room " + reservation.getUnitId().toString().substring(0, 8), result.get(0).unitName());
@@ -293,7 +309,7 @@ class AdminReservationServiceTest {
         .thenThrow(new RuntimeException("Connection error"));
 
     List<ReservationOverviewDto> result =
-        adminReservationService.getReservationsOverview(ownerId, null, false);
+        adminReservationService.getReservationsOverview(ownerId, null, false, null, null);
 
     assertTrue(result.isEmpty());
   }
@@ -304,7 +320,7 @@ class AdminReservationServiceTest {
     when(restTemplate.getForObject(anyString(), eq(UUID[].class))).thenReturn(null);
 
     List<ReservationOverviewDto> result =
-        adminReservationService.getReservationsOverview(ownerId, null, false);
+        adminReservationService.getReservationsOverview(ownerId, null, false, null, null);
 
     assertTrue(result.isEmpty());
   }


### PR DESCRIPTION
## Summary
This pull request introduces comprehensive Mobile Responsiveness (RWD) refactoring and implements React Code Splitting to optimize bundle size and deliver a flawless experience on mobile devices (phones and tablets). It resolves visual clipping, overlapping grids, misaligned headers, and broken layout toggles when using the platform on smaller screens.

## Linked issue
Closes #120 

## Scope of changes
- **Performance & Loading**: Refactored `frontend/src/App.tsx` routing tree to use `React.lazy()` dynamic imports wrapped in a `<Suspense>` boundary featuring a pulsing SaaS-themed loading indicator.
- **Dual Map & Card Layout**: Fixed the mobile map toggle on `frontend/src/pages/PropertiesPage.tsx`. Toggling map mode on mobile now hides the cards list (`hidden md:block`) and shows the map canvas full width (`w-full md:flex-1`), preventing empty display bugs.
- **Stackable Forms & Modals**: Converted grid fields in `frontend/src/components/BlockDatesModal.tsx`, `frontend/src/components/ManualReservationModal.tsx`, and `frontend/src/components/RegisterForm.tsx` from strict side-by-side grids to stackable layouts (`grid-cols-1 sm:grid-cols-2`) on phone screen sizes.
- **Responsive Padding & Cards Spacing**: Replaced static layout margins and paddings with responsive spacing tokens (outer container padding `p-4 md:p-8`, card paddings `p-4 md:p-6`) across:
  - `frontend/src/pages/PropertyDetailsPage.tsx`
  - `frontend/src/pages/SettlementDetailsPage.tsx` (also updated the currency info card grid to use `grid-cols-1 sm:grid-cols-2`)
  - `frontend/src/pages/ReservationDetailsPage.tsx`
  - `frontend/src/pages/ProfilePage.tsx`
  - `frontend/src/pages/MeterReadingsPage.tsx`
  - `frontend/src/pages/AdminMeterReadingsPage.tsx`
- **Mobile Navigation & Calendars**: Implemented responsive mobile drawer toggles in `frontend/src/components/Navbar.tsx`, datepicker day wrapping overrides in `frontend/src/App.css`, and custom horizontal scroll container rules for `frontend/src/pages/OccupancyCalendarPage.tsx`.
- **Mobile-First Tables**: Converted reservation lists in `frontend/src/components/AdminReservationList.tsx` to block cards on viewports under `md`.

## Testing status
- [x] Tested locally (Vite production build compiled successfully via `npm run build` in 2.85s; manual verification conducted under simulated screen widths down to 320px for iOS and Android layouts)

## Checklist
- [x] PR title is clear and meaningful
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] Ready for review