### PR TITLE
Update requirements.txt

### DIFF
--- a/services/ocr-service/requirements.txt
+++ b/services/ocr-service/requirements.txt
@@ -1,9 +1,14 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+torch==2.7.0+cpu
+torchvision==0.22.0+cpu
+
 fastapi>=0.110.0
 uvicorn[standard]>=0.24.0
 python-multipart
 python-dotenv
 ultralytics
-opencv-python
+opencv-python-headless
 numpy
 pillow
 pillow-heif


### PR DESCRIPTION
## Summary
Updates the OCR service dependencies to use CPU-only ML packages and avoid pulling large CUDA/NVIDIA dependencies during Docker builds.

## Linked issue
Closes #187

## Scope of changes
Describe the main changes included in this pull request.

- Pin CPU-only PyTorch dependencies for the OCR service
- Replace the regular OpenCV package with the headless variant
- Reduce Docker build risk caused by oversized GPU-related dependencies

## Testing status
Describe how this was verified.

- [x] Tested locally
- [x] Existing tests pass

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Ready for review