### PR TITLE
Add reservation integration test and docs

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,0 +1,130 @@
+# Integration Tests
+
+This document describes the integration tests in the KWATERA project, including what each test covers, how the Spring context is set up, and how to run the tests locally.
+
+---
+
+## 1. Billing-Service Integration Test
+
+**File**:
+`services/billing-service/src/test/java/io/github/kwatera_project/kwatera/billing_service/integration/BillingIntegrationTest.java`
+
+### Spring Context
+
+The test uses `@SpringBootTest` without `webEnvironment`, which loads the full application context without starting an HTTP server. Service beans and repositories are autowired directly into the test class.
+
+### Database
+
+A **real PostgreSQL database** is provided by **Testcontainers** (`@Testcontainers`, `@Container`). A `postgres:16-alpine` container is started once for the test class and its JDBC URL, username, and password are registered dynamically via `@DynamicPropertySource`. The schema is managed by `spring.jpa.hibernate.ddl-auto=create-drop`.
+
+### What the Test Covers
+
+The test exercises the full settlement and media-reading lifecycle without mocking the service or repository layers:
+
+| Scenario | Description |
+|---|---|
+| **Create settlement** | `SettlementService.createSettlement(...)` persists a settlement with correct amounts |
+| **Persist to PostgreSQL** | Settlement is readable from `SettlementRepository` after creation |
+| **Add utility charge** | `addUtilitySettlementItem(...)` appends a water charge and recalculates totals |
+| **Register payment** | `registerPayment(...)` updates `amountPaid` and `balanceDue` |
+| **Block duplicate utility charge** | A second water charge for the same unit throws `IllegalStateException` |
+| **OCR auto-approved reading** | A high-confidence OCR result triggers a water charge automatically |
+| **OCR invalid value** | An unparseable OCR reading sets status `REQUEST_REUPLOAD`, no charge added |
+| **OCR low-confidence reading** | A below-threshold confidence score sets status `REQUEST_REUPLOAD`, no charge added |
+
+### External Dependencies Mocked
+
+| Bean | Why mocked |
+|---|---|
+| `OcrClient` | Avoids calls to an external OCR HTTP service |
+| `PropertyClient` | Avoids calls to the property-service |
+| `ReservationClient` | Avoids calls to the reservation-service |
+| `SettlementEventPublisher` | Avoids Kafka event publishing |
+| `EmailNotificationService` | Avoids SMTP mail sending |
+
+---
+
+## 2. Reservation-Service Integration Test
+
+**File**:
+`services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/integration/ReservationIntegrationTest.java`
+
+### Spring Context
+
+The test uses `@SpringBootTest(webEnvironment = MOCK)` together with `@AutoConfigureMockMvc`. This loads the **full** application context (real `ReservationService`, real `ReservationRepository`, real JPA with H2) and exposes the Spring MVC layer through `MockMvc`. Requests pass through the complete security filter chain, which means authentication must be provided explicitly.
+
+### Database
+
+An **in-memory H2 database** is used. The base configuration lives in `src/test/resources/application.yaml` (already present in the repository) and sets:
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+```
+
+Hibernate creates and drops the schema automatically. No Docker or external database is required.
+
+### What the Test Covers
+
+The test exercises the full HTTP → Controller → Service → Repository path:
+
+| Scenario | Description |
+|---|---|
+| **Create reservation** | `POST /api/v1/reservations` as `ROLE_GUEST` returns `201 Created` |
+| **Persistence check** | Exactly one `Reservation` row exists in `ReservationRepository` after the request |
+| **Field assertions** | `unitId`, `userId`, `startDate`, `endDate`, `status = PENDING`, `pricePerNightSnapshot`, `totalPrice = pricePerNight × nights` all match expected values |
+| **Overlap rejection** | A second `POST` for the same unit with an overlapping date range returns `409 Conflict` |
+| **No duplicate persisted** | After the conflicting request the repository still contains exactly one reservation |
+
+### External Dependencies Mocked
+
+| Bean | Why mocked |
+|---|---|
+| `RestOperations` | Replaces the load-balanced `RestTemplate` used by `ReservationService` to fetch unit price from property-service |
+| `NbpExchangeRateClient` | Avoids outbound HTTP calls to the NBP exchange-rate API |
+| `EmailNotificationService` | Avoids SMTP side effects |
+| `SystemEventService` | Avoids audit-event persistence (keeps assertions focused on the reservation row) |
+| `JavaMailSender` | Prevents Spring Mail from requiring a real SMTP server at context startup |
+| `BusinessDateProvider` | Returns a fixed deterministic date so reservation dates are always in the future |
+
+### Authentication
+
+Authentication is injected via `SecurityMockMvcRequestPostProcessors.authentication(...)`, setting up a `UsernamePasswordAuthenticationToken` with `ROLE_GUEST` and the user-id stored in the `details` field — the same convention used by the production `JwtAuthFilter`.
+
+---
+
+## 3. Running the Tests Locally
+
+### Reservation-Service Tests
+
+```bash
+# Run all tests in reservation-service (unit + integration)
+mvn -pl services/reservation-service test
+```
+
+No Docker is required. H2 is started in-memory automatically.
+
+### Billing-Service Tests
+
+```bash
+# Run all tests in billing-service (unit + integration)
+mvn -pl services/billing-service test
+```
+
+> [!IMPORTANT]
+> The billing-service integration test **requires Docker** because it uses Testcontainers to start a PostgreSQL container. Make sure Docker Desktop (or another OCI-compatible runtime) is running before executing this command.
+
+### All Services
+
+```bash
+# Run all tests across the entire multi-module project
+mvn test
+```
+
+> [!NOTE]
+> Running all modules will also require Docker due to the billing-service Testcontainers dependency.

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/integration/ReservationIntegrationTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/integration/ReservationIntegrationTest.java
@@ -1,0 +1,255 @@
+package io.github.kwatera_project.kwatera.reservation_service.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.kwatera_project.kwatera.reservation_service.audit.SystemEventService;
+import io.github.kwatera_project.kwatera.reservation_service.client.NbpExchangeRateClient;
+import io.github.kwatera_project.kwatera.reservation_service.dto.UnitDto;
+import io.github.kwatera_project.kwatera.reservation_service.event.SettlementEventListener;
+import io.github.kwatera_project.kwatera.reservation_service.model.Reservation;
+import io.github.kwatera_project.kwatera.reservation_service.model.ReservationStatus;
+import io.github.kwatera_project.kwatera.reservation_service.repository.ReservationRepository;
+import io.github.kwatera_project.kwatera.reservation_service.service.BusinessDateProvider;
+import io.github.kwatera_project.kwatera.reservation_service.service.EmailNotificationService;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestOperations;
+
+// Full Spring context with in-memory H2 (configured via src/test/resources/application.yaml).
+// External infrastructure (Eureka, Config Server, Kafka, mail, property-service, NBP API)
+// is either disabled through test properties or replaced with Mockito mocks.
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = {
+      // Disable Spring Cloud service discovery and config server
+      "spring.cloud.discovery.enabled=false",
+      "eureka.client.enabled=false",
+      "spring.cloud.config.enabled=false",
+      // Point Kafka to a non-existing broker so the consumer never connects
+      "spring.kafka.bootstrap-servers=localhost:19999",
+      // Provide a dummy JWT secret so JwtService can initialise
+      "jwt.secret=dGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQtdGVzdC1zZWNyZXQ=",
+      // Mail configuration – JavaMailSender bean is mocked, but properties must resolve
+      "spring.mail.host=localhost",
+      "spring.mail.port=1025",
+      // Business zone used by BusinessDateProvider (mocked, but the property must parse)
+      "kwatera.business-zone=Europe/Warsaw",
+      "kwatera.mail.from=no-reply@kwatera.test",
+      "kwatera.mail.test-recipient=test@kwatera.test",
+      // Keep DDL in sync with the entity model for the H2 test database
+      "spring.jpa.hibernate.ddl-auto=create-drop",
+      "spring.jpa.show-sql=false",
+      // Disable mail health indicator – the actuator requires real mail beans, but we mock them
+      "management.health.mail.enabled=false",
+      // Prevent Kafka listener containers from auto-starting at context startup.
+      // The ConsumerFactory and ContainerFactory beans are mocked below, so no real
+      // broker connection is attempted.
+      "spring.kafka.listener.auto-startup=false"
+    })
+@AutoConfigureMockMvc
+class ReservationIntegrationTest {
+
+  // ── MockMvc wired with the full security filter chain ────────────────────────
+
+  @Autowired private MockMvc mockMvc;
+
+  // ── Real beans under test ────────────────────────────────────────────────────
+
+  @Autowired private ReservationRepository reservationRepository;
+
+  // ── External dependencies replaced with mocks ───────────────────────────────
+
+  // RestOperations is the interface implemented by the @LoadBalanced RestTemplate
+  // that ReservationService uses for property-service calls.
+  @MockitoBean private RestOperations restOperations;
+
+  // Prevents outbound calls to the NBP exchange-rate API.
+  @MockitoBean private NbpExchangeRateClient nbpExchangeRateClient;
+
+  // Prevents actual SMTP/mail-sender calls.
+  @MockitoBean private EmailNotificationService emailNotificationService;
+
+  // Prevents audit event persistence from interfering with test assertions.
+  @MockitoBean private SystemEventService systemEventService;
+
+  // Satisfies JavaMailSender autowiring inside Spring Mail autoconfiguration,
+  // keeping the context load clean even without a real mail server.
+  @MockitoBean private JavaMailSender javaMailSender;
+
+  // Fixes the "today" date so test dates are always deterministic and in the future.
+  @MockitoBean private BusinessDateProvider businessDateProvider;
+
+  // Mocking the Kafka ConsumerFactory and listener container factory prevents
+  // KafkaConsumerConfig from attempting a real TCP connection to kafka:9092
+  // (which is only available inside Docker and would fail in CI/local test runs).
+  @MockitoBean private ConsumerFactory<String, byte[]> consumerFactory;
+
+  @MockitoBean
+  private ConcurrentKafkaListenerContainerFactory<String, byte[]> kafkaListenerContainerFactory;
+
+  // Mocking SettlementEventListener replaces the @KafkaListener-annotated bean
+  // so that its listener is never registered with the Kafka infrastructure.
+  @MockitoBean private SettlementEventListener settlementEventListener;
+
+  // ── Test fixtures ────────────────────────────────────────────────────────────
+
+  private static final UUID UNIT_ID = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  private static final UUID USER_ID = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+  private static final BigDecimal PRICE_PER_NIGHT = new BigDecimal("200.00");
+  // Fixed "today" – all reservation dates will be strictly after this.
+  private static final LocalDate FIXED_TODAY = LocalDate.of(2027, 1, 1);
+  private static final LocalDate START_DATE = LocalDate.of(2027, 6, 10);
+  private static final LocalDate END_DATE = LocalDate.of(2027, 6, 15); // 5 billable nights
+
+  @BeforeEach
+  void setUp() {
+    // Clean the H2 database before each test so tests are independent.
+    reservationRepository.deleteAll();
+
+    // Fix today so that START_DATE is always in the future relative to the service check.
+    when(businessDateProvider.today()).thenReturn(FIXED_TODAY);
+
+    // Stub the property-service REST call that ReservationService.fetchUnitPrice() makes.
+    // The service uses RestOperations.exchange(url, GET, entity, UnitDto.class, unitId).
+    UnitDto unitDto = new UnitDto();
+    unitDto.setPricePerNight(PRICE_PER_NIGHT);
+    ResponseEntity<UnitDto> unitResponse = ResponseEntity.ok(unitDto);
+    when(restOperations.exchange(
+            anyString(), eq(HttpMethod.GET), any(), eq(UnitDto.class), any(UUID.class)))
+        .thenReturn(unitResponse);
+
+    // Stub email notifications to be no-ops (the mock records calls but does nothing).
+    doNothing().when(emailNotificationService).sendReservationCreated(any(), anyString());
+    doNothing().when(emailNotificationService).sendOwnerReservationCreated(any());
+
+    // Stub system event logging to be a no-op.
+    doNothing().when(systemEventService).logSafely(any(), any(), anyString(), any(), anyString());
+  }
+
+  // Builds a fully authenticated principal with the given roles.
+  // The user-id is stored in the Authentication's details field,
+  // mirroring how JwtAuthFilter populates it in production.
+  private Authentication buildGuestAuth(UUID userId) {
+    List<GrantedAuthority> authorities =
+        Arrays.stream(new String[] {"ROLE_GUEST"})
+            .map(SimpleGrantedAuthority::new)
+            .collect(Collectors.toList());
+    UsernamePasswordAuthenticationToken auth =
+        new UsernamePasswordAuthenticationToken("guest@kwatera.test", null, authorities);
+    auth.setDetails(userId.toString());
+    return auth;
+  }
+
+  // Convenience helper: builds the JSON body for a valid guest reservation request.
+  private String reservationJson(UUID unitId, LocalDate start, LocalDate end) {
+    return String.format(
+        "{\"unitId\":\"%s\",\"startDate\":\"%s\",\"endDate\":\"%s\"}", unitId, start, end);
+  }
+
+  // Verifies that a guest can create a reservation via the HTTP layer and that the
+  // created entity is correctly persisted in the H2 database.
+  @Test
+  void shouldCreateReservationAndPersistIt() throws Exception {
+    String json = reservationJson(UNIT_ID, START_DATE, END_DATE);
+
+    mockMvc
+        .perform(
+            post("/api/v1/reservations")
+                .header("Authorization", "Bearer mock-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .with(authentication(buildGuestAuth(USER_ID))))
+        .andExpect(status().isCreated());
+
+    // Assert exactly one reservation was persisted.
+    List<Reservation> all = reservationRepository.findAll();
+    assertThat(all).hasSize(1);
+
+    Reservation saved = all.get(0);
+
+    // Assert core fields match the request payload.
+    assertThat(saved.getUnitId()).isEqualTo(UNIT_ID);
+    assertThat(saved.getUserId()).isEqualTo(USER_ID);
+    assertThat(saved.getStartDate()).isEqualTo(START_DATE);
+    assertThat(saved.getEndDate()).isEqualTo(END_DATE);
+
+    // A guest reservation must be created in PENDING status.
+    assertThat(saved.getStatus()).isEqualTo(ReservationStatus.PENDING);
+
+    // Price snapshot must come from the mocked property-service response.
+    assertThat(saved.getPricePerNightSnapshot()).isEqualByComparingTo(PRICE_PER_NIGHT);
+
+    // Total price = pricePerNight * billable nights (5 nights: June 10 – June 15).
+    long expectedNights = java.time.temporal.ChronoUnit.DAYS.between(START_DATE, END_DATE);
+    BigDecimal expectedTotal = PRICE_PER_NIGHT.multiply(BigDecimal.valueOf(expectedNights));
+    assertThat(saved.getTotalPrice()).isEqualByComparingTo(expectedTotal);
+
+    // Id must have been assigned by the database.
+    assertThat(saved.getId()).isNotNull();
+  }
+
+  // Verifies that a second reservation for the same unit with an overlapping date range
+  // is rejected with HTTP 409 Conflict and that no additional reservation is persisted.
+  @Test
+  void shouldRejectOverlappingReservationWithConflict() throws Exception {
+    String json = reservationJson(UNIT_ID, START_DATE, END_DATE);
+
+    // First reservation – must succeed.
+    mockMvc
+        .perform(
+            post("/api/v1/reservations")
+                .header("Authorization", "Bearer mock-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .with(authentication(buildGuestAuth(USER_ID))))
+        .andExpect(status().isCreated());
+
+    assertThat(reservationRepository.findAll()).hasSize(1);
+
+    // Second reservation for the same unit and overlapping dates – must be rejected.
+    LocalDate overlapStart = START_DATE.plusDays(2); // June 12 – overlaps with June 10–15
+    LocalDate overlapEnd = END_DATE.plusDays(2); // June 17
+    String overlapJson = reservationJson(UNIT_ID, overlapStart, overlapEnd);
+
+    mockMvc
+        .perform(
+            post("/api/v1/reservations")
+                .header("Authorization", "Bearer mock-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(overlapJson)
+                .with(authentication(buildGuestAuth(USER_ID))))
+        .andExpect(status().isConflict());
+
+    // Repository must still contain exactly the first reservation only.
+    assertThat(reservationRepository.findAll()).hasSize(1);
+  }
+}


### PR DESCRIPTION
## Summary

Add integration test documentation and a new reservation-service integration test for a critical reservation flow.

This PR adds `docs/integration-tests.md`, describing the existing billing-service integration test setup and the new reservation-service integration test setup, including local run commands. The billing-service test is documented as a PostgreSQL/Testcontainers-based integration test, while the reservation-service test is documented as an H2-based Spring Boot integration test.

This PR also adds `ReservationIntegrationTest` in `reservation-service`. The test loads a full Spring context with MockMvc, uses the real `ReservationService` and `ReservationRepository`, and mocks external dependencies such as property-service calls, NBP exchange-rate calls, email notifications, system events, mail sender, business date provider, and Kafka-related beans.

The new test covers:
- creating a reservation through the HTTP layer and verifying persisted fields, status, price snapshot, and total price,
- rejecting overlapping reservations with HTTP 409 and preventing duplicate persistence.

## Linked issue

Closes #180

## Scope of changes

- Added `docs/integration-tests.md` with integration test descriptions and local run commands for billing-service and reservation-service.
- Added `services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/integration/ReservationIntegrationTest.java`.
- Added integration coverage for reservation creation and overlapping reservation rejection using full Spring context, MockMvc, H2, real service/repository logic, and mocked external dependencies.

## Testing status

- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass

Verified locally with:

```bash
cd services/reservation-service
./mvnw -B -ntp spotless:check
./mvnw -B -ntp clean verify
./mvnw -B -ntp spotbugs:check
````

Note: Docker environment was not verified because this PR only changes tests and documentation, and the new integration test uses H2 with mocked external dependencies.

## Checklist

* [x] PR title is clear and meaningful
* [x] Linked issue is included
* [x] Scope matches the issue
* [x] No unrelated changes were added
* [x] Documentation updated if needed
* [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
* [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
* [x] Ready for review