### PR TITLE
Resolve missing guest email and name in occupancy calendar popover

### DIFF
--- a/frontend/src/api/reservationApi.ts
+++ b/frontend/src/api/reservationApi.ts
@@ -141,6 +141,7 @@ export async function createManualReservation(
             status: reservation.status,
             guestName: reservation.guestName,
             totalPrice: reservation.totalPrice,
+            guestEmail: reservation.guestEmail,
         });
 
         if (!demoOccupiedDatesByUnit[unitId]) {

--- a/frontend/src/components/BlockDatesModal.tsx
+++ b/frontend/src/components/BlockDatesModal.tsx
@@ -28,6 +28,7 @@ interface Occupancy {
     status: string;
     guestName?: string;
     totalPrice?: number;
+    guestEmail?: string;
 }
 
 const getOccupiedRange = (startDateStr: string, endDateStr: string) => {

--- a/frontend/src/components/ManualReservationModal.tsx
+++ b/frontend/src/components/ManualReservationModal.tsx
@@ -28,6 +28,7 @@ interface Occupancy {
     status: string;
     guestName?: string;
     totalPrice?: number;
+    guestEmail?: string;
 }
 
 const getOccupiedRange = (startDateStr: string, endDateStr: string) => {

--- a/frontend/src/demo/demoReservations.ts
+++ b/frontend/src/demo/demoReservations.ts
@@ -1,4 +1,4 @@
-import type { CurrencyMetadata, GuestReservation, ReservationDetails } from "../types/reservation";
+import type { CurrencyMetadata, GuestReservation, ReservationDetails, Occupancy } from "../types/reservation";
 import { demoProperties, demoUnitsByProperty } from "./demoProperties";
 
 const ownerName = "Piotr Wisniewski";
@@ -121,7 +121,7 @@ export const demoAdminReservations = demoReservations.map((item) => ({
     totalPrice: item.totalPrice,
 }));
 
-export const demoOccupancy = demoReservations
+export const demoOccupancy: Occupancy[] = demoReservations
     .filter((item) => item.status !== "CANCELLED")
     .map((item) => ({
         reservationId: item.id,
@@ -132,6 +132,7 @@ export const demoOccupancy = demoReservations
         status: item.status,
         guestName: item.guestName,
         totalPrice: item.totalPrice,
+        guestEmail: item.guestEmail,
     }));
 
 export const demoGuestReservations: GuestReservation[] = demoReservations

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -726,6 +726,7 @@
     "accommodation": "Accommodation",
     "financialSummary": "Financial Summary",
     "unassignedGuest": "Unassigned Guest",
+    "unknownGuest": "Unknown Guest",
     "viewFullDetails": "View Full Details",
     "close": "Close"
   },

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -721,6 +721,7 @@
     "accommodation": "Zakwaterowanie",
     "financialSummary": "Podsumowanie finansowe",
     "unassignedGuest": "Nieprzypisany gość",
+    "unknownGuest": "nieznany gość",
     "viewFullDetails": "Zobacz pełne szczegóły",
     "close": "Zamknij"
   },

--- a/frontend/src/pages/OccupancyCalendarPage.tsx
+++ b/frontend/src/pages/OccupancyCalendarPage.tsx
@@ -28,6 +28,7 @@ interface Occupancy {
     status: string;
     guestName?: string;
     totalPrice?: number;
+    guestEmail?: string;
 }
 
 export default function OccupancyCalendarPage() {
@@ -459,6 +460,11 @@ export default function OccupancyCalendarPage() {
                                             <p className="text-sm font-bold text-brand-main mt-0.5">
                                                 {formatGuestLabel(selectedOcc.guestName)}
                                             </p>
+                                            {selectedOcc.reservationId && (
+                                                <p className="text-xs text-brand-muted mt-0.5 break-all">
+                                                    {selectedOcc.guestEmail || t('occupancy.unknownGuest', { defaultValue: 'nieznany gość' })}
+                                                </p>
+                                            )}
                                         </div>
                                         <div>
                                             <span

--- a/frontend/src/types/reservation.ts
+++ b/frontend/src/types/reservation.ts
@@ -39,3 +39,15 @@ export interface GuestReservation {
     convertedTotalPrice?: number;
     currencyInfo?: CurrencyMetadata;
 }
+
+export interface Occupancy {
+    reservationId: string;
+    unitId: string;
+    unitName?: string;
+    startDate: string;
+    endDate: string;
+    status: string;
+    guestName?: string;
+    totalPrice?: number;
+    guestEmail?: string;
+}

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/dto/OccupancyDto.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/dto/OccupancyDto.java
@@ -11,6 +11,8 @@ public class OccupancyDto {
   private LocalDate startDate;
   private LocalDate endDate;
   private String status;
+  private String guestEmail;
+  private String guestName;
 
   public OccupancyDto() {}
 
@@ -20,13 +22,17 @@ public class OccupancyDto {
       String unitName,
       LocalDate startDate,
       LocalDate endDate,
-      String status) {
+      String status,
+      String guestEmail,
+      String guestName) {
     this.reservationId = reservationId;
     this.unitId = unitId;
     this.unitName = unitName;
     this.startDate = startDate;
     this.endDate = endDate;
     this.status = status;
+    this.guestEmail = guestEmail;
+    this.guestName = guestName;
   }
 
   public UUID getReservationId() {
@@ -75,5 +81,21 @@ public class OccupancyDto {
 
   public void setStatus(String status) {
     this.status = status;
+  }
+
+  public String getGuestEmail() {
+    return guestEmail;
+  }
+
+  public void setGuestEmail(String guestEmail) {
+    this.guestEmail = guestEmail;
+  }
+
+  public String getGuestName() {
+    return guestName;
+  }
+
+  public void setGuestName(String guestName) {
+    this.guestName = guestName;
   }
 }

--- a/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
+++ b/services/reservation-service/src/main/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationService.java
@@ -140,8 +140,19 @@ public class ReservationService {
     java.util.Set<UUID> unitsWithReservations = new java.util.HashSet<>();
     List<OccupancyDto> result = new java.util.ArrayList<>();
 
+    java.util.Map<UUID, String> guestNames = new java.util.HashMap<>();
+    for (Reservation r : reservations) {
+      if (r.getStatus() != ReservationStatus.BLOCKED && r.getUserId() != null) {
+        guestNames.computeIfAbsent(r.getUserId(), this::fetchGuestName);
+      }
+    }
+
     for (Reservation r : reservations) {
       unitsWithReservations.add(r.getUnitId());
+      String guestName = null;
+      if (r.getStatus() != ReservationStatus.BLOCKED && r.getUserId() != null) {
+        guestName = guestNames.get(r.getUserId());
+      }
       result.add(
           new OccupancyDto(
               r.getId(),
@@ -150,7 +161,9 @@ public class ReservationService {
                   r.getUnitId(), "Room " + r.getUnitId().toString().substring(0, 8)),
               r.getStartDate(),
               r.getEndDate(),
-              r.getStatus().name()));
+              r.getStatus().name(),
+              r.getGuestEmail(),
+              guestName));
     }
 
     for (UUID unitId : allUnitIds) {
@@ -162,7 +175,9 @@ public class ReservationService {
                 unitNames.getOrDefault(unitId, "Room " + unitId.toString().substring(0, 8)),
                 null,
                 null,
-                "FREE"));
+                "FREE",
+                null,
+                null));
       }
     }
 
@@ -443,7 +458,7 @@ public class ReservationService {
     dto.setConvertedTotalPrice(convertedTotalPrice);
     dto.setCurrencyInfo(currencyInfo);
 
-    dto.setGuestName("Guest " + reservation.getUserId().toString().substring(0, 8));
+    dto.setGuestName(fetchGuestName(reservation.getUserId()));
     dto.setUnitName("Unknown Room");
     dto.setCity("Unknown City");
 
@@ -758,5 +773,35 @@ public class ReservationService {
         + oldStatus
         + ", newStatus="
         + newStatus;
+  }
+
+  private String fetchGuestName(UUID userId) {
+    if (userId == null) {
+      return null;
+    }
+    try {
+      String url = authServiceUrl + "/internal/{userId}";
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("X-Internal-Token", internalToken);
+      HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+      ResponseEntity<java.util.Map> response =
+          restOperations().exchange(url, HttpMethod.GET, entity, java.util.Map.class, userId);
+
+      if (response.getBody() != null) {
+        String firstName = (String) response.getBody().get("firstName");
+        String lastName = (String) response.getBody().get("lastName");
+        if (firstName != null && lastName != null) {
+          return firstName + " " + lastName;
+        } else if (firstName != null) {
+          return firstName;
+        } else if (lastName != null) {
+          return lastName;
+        }
+      }
+    } catch (Exception e) {
+      log.warn("Failed to fetch guest details for user {}: {}", userId, e.getMessage());
+    }
+    return "Guest " + userId.toString().substring(0, 8);
   }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminOccupancyControllerTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/controller/AdminOccupancyControllerTest.java
@@ -34,7 +34,15 @@ class AdminOccupancyControllerTest {
     LocalDate end = start.plusDays(7);
 
     OccupancyDto dto =
-        new OccupancyDto(UUID.randomUUID(), UUID.randomUUID(), "Unit A", start, end, "CONFIRMED");
+        new OccupancyDto(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "Unit A",
+            start,
+            end,
+            "CONFIRMED",
+            "guest@example.com",
+            "Guest " + ownerId);
     when(service.getOccupancy(start, end, ownerId, true)).thenReturn(List.of(dto));
 
     Authentication auth = buildAuth("ROLE_ADMIN", ownerId.toString());
@@ -54,7 +62,15 @@ class AdminOccupancyControllerTest {
     LocalDate end = start.plusDays(3);
 
     OccupancyDto dto =
-        new OccupancyDto(UUID.randomUUID(), UUID.randomUUID(), "Unit B", start, end, "PENDING");
+        new OccupancyDto(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "Unit B",
+            start,
+            end,
+            "PENDING",
+            "guest@example.com",
+            "Guest " + ownerId);
     when(service.getOccupancy(start, end, ownerId, false)).thenReturn(List.of(dto));
 
     Authentication auth = buildAuth("ROLE_OWNER", ownerId.toString());

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/dto/OccupancyDtoTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/dto/OccupancyDtoTest.java
@@ -16,7 +16,15 @@ class OccupancyDtoTest {
     LocalDate end = LocalDate.of(2026, 6, 7);
 
     OccupancyDto dto =
-        new OccupancyDto(reservationId, unitId, "Suite 101", start, end, "CONFIRMED");
+        new OccupancyDto(
+            reservationId,
+            unitId,
+            "Suite 101",
+            start,
+            end,
+            "CONFIRMED",
+            "guest@example.com",
+            "Guest Name");
 
     assertEquals(reservationId, dto.getReservationId());
     assertEquals(unitId, dto.getUnitId());
@@ -24,6 +32,8 @@ class OccupancyDtoTest {
     assertEquals(start, dto.getStartDate());
     assertEquals(end, dto.getEndDate());
     assertEquals("CONFIRMED", dto.getStatus());
+    assertEquals("guest@example.com", dto.getGuestEmail());
+    assertEquals("Guest Name", dto.getGuestName());
   }
 
   @Test
@@ -40,6 +50,8 @@ class OccupancyDtoTest {
     dto.setStartDate(start);
     dto.setEndDate(end);
     dto.setStatus("PENDING");
+    dto.setGuestEmail("guest@example.com");
+    dto.setGuestName("Guest Name");
 
     assertEquals(reservationId, dto.getReservationId());
     assertEquals(unitId, dto.getUnitId());
@@ -47,5 +59,7 @@ class OccupancyDtoTest {
     assertEquals(start, dto.getStartDate());
     assertEquals(end, dto.getEndDate());
     assertEquals("PENDING", dto.getStatus());
+    assertEquals("guest@example.com", dto.getGuestEmail());
+    assertEquals("Guest Name", dto.getGuestName());
   }
 }

--- a/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
+++ b/services/reservation-service/src/test/java/io/github/kwatera_project/kwatera/reservation_service/service/ReservationServiceTest.java
@@ -833,6 +833,193 @@ class ReservationServiceTest {
     assertEquals(1, reservedCount);
   }
 
+  @Test
+  void getOccupancy_resolvesGuestNameWithFirstAndLastName() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ReservationService service =
+        reservationService(repository, restTemplate, mock(NbpExchangeRateClient.class));
+
+    UUID unitId = UUID.randomUUID();
+    LocalDate start = LocalDate.now();
+    LocalDate end = start.plusDays(7);
+    UUID guestId = UUID.randomUUID();
+
+    Reservation r = new Reservation();
+    r.setId(UUID.randomUUID());
+    r.setUnitId(unitId);
+    r.setUserId(guestId);
+    r.setStartDate(start);
+    r.setEndDate(end);
+    r.setStatus(ReservationStatus.CONFIRMED);
+
+    when(restTemplate.getForObject(contains("/units/ids"), eq(UUID[].class)))
+        .thenReturn(new UUID[] {unitId});
+    when(repository.findByUnitIdIn(List.of(unitId))).thenReturn(List.of(r));
+
+    java.util.Map<String, Object> userProfile = new java.util.HashMap<>();
+    userProfile.put("firstName", "John");
+    userProfile.put("lastName", "Doe");
+    ResponseEntity<java.util.Map> responseEntity = new ResponseEntity<>(userProfile, HttpStatus.OK);
+
+    when(restTemplate.exchange(
+            contains("/internal/"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(java.util.Map.class),
+            eq(guestId)))
+        .thenReturn(responseEntity);
+
+    List<io.github.kwatera_project.kwatera.reservation_service.dto.OccupancyDto> result =
+        service.getOccupancy(start, end, UUID.randomUUID(), true);
+
+    assertEquals(1, result.size());
+    assertEquals("John Doe", result.get(0).getGuestName());
+  }
+
+  @Test
+  void getOccupancy_resolvesGuestNameWithOnlyFirstName() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ReservationService service =
+        reservationService(repository, restTemplate, mock(NbpExchangeRateClient.class));
+
+    UUID unitId = UUID.randomUUID();
+    LocalDate start = LocalDate.now();
+    LocalDate end = start.plusDays(7);
+    UUID guestId = UUID.randomUUID();
+
+    Reservation r = new Reservation();
+    r.setId(UUID.randomUUID());
+    r.setUnitId(unitId);
+    r.setUserId(guestId);
+    r.setStartDate(start);
+    r.setEndDate(end);
+    r.setStatus(ReservationStatus.CONFIRMED);
+
+    when(restTemplate.getForObject(contains("/units/ids"), eq(UUID[].class)))
+        .thenReturn(new UUID[] {unitId});
+    when(repository.findByUnitIdIn(List.of(unitId))).thenReturn(List.of(r));
+
+    java.util.Map<String, Object> userProfile = new java.util.HashMap<>();
+    userProfile.put("firstName", "John");
+    ResponseEntity<java.util.Map> responseEntity = new ResponseEntity<>(userProfile, HttpStatus.OK);
+
+    when(restTemplate.exchange(
+            contains("/internal/"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(java.util.Map.class),
+            eq(guestId)))
+        .thenReturn(responseEntity);
+
+    List<io.github.kwatera_project.kwatera.reservation_service.dto.OccupancyDto> result =
+        service.getOccupancy(start, end, UUID.randomUUID(), true);
+
+    assertEquals(1, result.size());
+    assertEquals("John", result.get(0).getGuestName());
+  }
+
+  @Test
+  void getOccupancy_resolvesGuestNameWithOnlyLastName() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ReservationService service =
+        reservationService(repository, restTemplate, mock(NbpExchangeRateClient.class));
+
+    UUID unitId = UUID.randomUUID();
+    LocalDate start = LocalDate.now();
+    LocalDate end = start.plusDays(7);
+    UUID guestId = UUID.randomUUID();
+
+    Reservation r = new Reservation();
+    r.setId(UUID.randomUUID());
+    r.setUnitId(unitId);
+    r.setUserId(guestId);
+    r.setStartDate(start);
+    r.setEndDate(end);
+    r.setStatus(ReservationStatus.CONFIRMED);
+
+    when(restTemplate.getForObject(contains("/units/ids"), eq(UUID[].class)))
+        .thenReturn(new UUID[] {unitId});
+    when(repository.findByUnitIdIn(List.of(unitId))).thenReturn(List.of(r));
+
+    java.util.Map<String, Object> userProfile = new java.util.HashMap<>();
+    userProfile.put("lastName", "Doe");
+    ResponseEntity<java.util.Map> responseEntity = new ResponseEntity<>(userProfile, HttpStatus.OK);
+
+    when(restTemplate.exchange(
+            contains("/internal/"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(java.util.Map.class),
+            eq(guestId)))
+        .thenReturn(responseEntity);
+
+    List<io.github.kwatera_project.kwatera.reservation_service.dto.OccupancyDto> result =
+        service.getOccupancy(start, end, UUID.randomUUID(), true);
+
+    assertEquals(1, result.size());
+    assertEquals("Doe", result.get(0).getGuestName());
+  }
+
+  @Test
+  void getOccupancy_deduplicatesAuthCallsForSameGuest() {
+    ReservationRepository repository = mock(ReservationRepository.class);
+    RestTemplate restTemplate = mock(RestTemplate.class);
+    ReservationService service =
+        reservationService(repository, restTemplate, mock(NbpExchangeRateClient.class));
+
+    UUID unitId1 = UUID.randomUUID();
+    UUID unitId2 = UUID.randomUUID();
+    LocalDate start = LocalDate.now();
+    LocalDate end = start.plusDays(7);
+    UUID guestId = UUID.randomUUID();
+
+    Reservation r1 = new Reservation();
+    r1.setId(UUID.randomUUID());
+    r1.setUnitId(unitId1);
+    r1.setUserId(guestId);
+    r1.setStartDate(start);
+    r1.setEndDate(end);
+    r1.setStatus(ReservationStatus.CONFIRMED);
+
+    Reservation r2 = new Reservation();
+    r2.setId(UUID.randomUUID());
+    r2.setUnitId(unitId2);
+    r2.setUserId(guestId);
+    r2.setStartDate(start);
+    r2.setEndDate(end);
+    r2.setStatus(ReservationStatus.CONFIRMED);
+
+    when(restTemplate.getForObject(contains("/units/ids"), eq(UUID[].class)))
+        .thenReturn(new UUID[] {unitId1, unitId2});
+    when(repository.findByUnitIdIn(List.of(unitId1, unitId2))).thenReturn(List.of(r1, r2));
+
+    java.util.Map<String, Object> userProfile = new java.util.HashMap<>();
+    userProfile.put("firstName", "John");
+    userProfile.put("lastName", "Doe");
+    ResponseEntity<java.util.Map> responseEntity = new ResponseEntity<>(userProfile, HttpStatus.OK);
+
+    when(restTemplate.exchange(
+            contains("/internal/"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(java.util.Map.class),
+            eq(guestId)))
+        .thenReturn(responseEntity);
+
+    service.getOccupancy(start, end, UUID.randomUUID(), true);
+
+    verify(restTemplate, times(1))
+        .exchange(
+            contains("/internal/"),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(java.util.Map.class),
+            eq(guestId));
+  }
+
   // --------------- getOccupiedDates tests ---------------
 
   @Test


### PR DESCRIPTION
# Pull Request: Fix Missing Guest Details in Occupancy Calendar Popover
## Summary
This pull request resolves a bug in the Occupancy Calendar details popover. Previously, the guest's email was missing from the endpoint response (falling back to a default "nieznany gość" placeholder in the UI) and the guest's name was displayed as "Unassigned Guest" in production mode. This change ensures that both the guest email and their real first/last name are correctly retrieved, mapped, and displayed in the UI calendar popover.

## Linked issue
Closes #192 

## Scope of changes
- **Backend (reservation-service)**:
  - Updated `OccupancyDto.java` to include `guestEmail` and `guestName` fields, constructors, and getters/setters.
  - Modified `ReservationService.java` to extract the guest email from the database and retrieve/format the guest's real first and last name from the `auth-service` internal user endpoint.
  - Implemented a local Map caching system in `ReservationService` to deduplicate microservice network calls when loading calendar occupancy blocks.
  - Updated `AdminOccupancyControllerTest.java` and `OccupancyDtoTest.java` to match constructor changes and verify the new properties.
- **Frontend**:
  - Centralized the `Occupancy` calendar event type in `types/reservation.ts`.
  - Updated the Occupancy details modal inside `OccupancyCalendarPage.tsx` to render the guest's email below their name with an internationalized fallback.
  - Aligned the mock databases, `demoReservations.ts`, `reservationApi.ts`, and modal interfaces to conform to the new structure, achieving 100% green compilation.
  - Updated localization assets (`en.json` and `pl.json`) with the new fallback translations.

## Testing status
- [x] Tested locally
- [x] Relevant tests added
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
- [x] Ready for review