### PR TITLE
Add bedrooms and beds count to seed data

### DIFF
--- a/services/db-migrations/src/main/resources/db/migration/V29__add_bedrooms_and_beds_count.sql
+++ b/services/db-migrations/src/main/resources/db/migration/V29__add_bedrooms_and_beds_count.sql
@@ -1,0 +1,28 @@
+UPDATE units
+SET bedrooms = v.bedrooms,
+    beds      = v.beds
+    FROM (VALUES
+    -- Cottages / cabins
+    ('Room 1',                    1, 1), -- capacity 2
+    ('Family Suite',              2, 3), -- capacity 5
+    ('Entire Forest Cabin',       3, 3), -- capacity 6
+    ('Entire Mountain Cabin',     4, 4), -- capacity 8
+    ('Entire Nature Cabin',       4, 4), -- capacity 8
+    ('Attic Room',                1, 1), -- capacity 2
+    ('Entire Lakeside Cottage',   3, 3), -- capacity 6
+
+    -- Apartments (first units)
+    ('Studio 1',                  1, 1), -- capacity 2
+    ('Apartment Deluxe',          2, 2), -- capacity 4
+    ('City Center Apartment',     2, 2), -- capacity 4
+    ('Historic Center Apartment', 2, 2), -- capacity 4
+    ('Odra View Apartment',       1, 2), -- capacity 3
+    ('Beachside Apartment',       2, 2), -- capacity 4
+    ('Executive Apartment',       2, 2), -- capacity 4
+    ('Premium City Apartment',     2, 2), -- capacity 4
+    ('Riverside Deluxe Apartment', 1, 2), -- capacity 3
+    ('Executive Plus Apartment',   2, 2), -- capacity 4
+    ('Seaside Luxury Apartment',   2, 2), -- capacity 4
+    ('Old Town Comfort Apartment', 2, 2)  -- capacity 4
+) AS v(name, bedrooms, beds)
+WHERE units.name = v.name;


### PR DESCRIPTION
## Summary
Add realistic bedroom and bed counts to property units via Flyway migrations to provide correct capacity filtering logic and improve user experience.

## Linked issue
Closes #194 

## Scope of changes
Describe the main changes included in this pull request.

- Add Flyway SQL migration: `V29__add_bedrooms_and_beds_count.sql`

## Testing status

- [x] Tested locally
- [x] Existing tests pass
- [x] Docker environment verified with `docker compose -f infra/compose/docker-compose.yml up --build` if applicable

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Documentation updated if needed
- [x] CODEOWNERS updated if this PR adds or changes ownership of a service, module, directory, or major feature area
- [x] OpenAPI/Swagger verified and updated if this PR adds, removes, or changes backend API endpoints, DTOs, request/response contracts, or authorization rules
- [x] Ready for review