### PR TITLE
Polish remove hardcoded developerdemo shortcuts leaking into public views

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,8 +7,6 @@ import ExploreSection from '../components/landing/ExploreSection';
 import BlogSection from '../components/landing/BlogSection';
 import NewsletterSection from '../components/landing/NewsletterSection';
 import TrustBadges from '../components/landing/TrustBadges';
-import DemoRoleSelector from "../components/DemoRoleSelector";
-import { IS_DEMO_MODE } from "../api/apiConfig";
 import { useTranslation } from "react-i18next";
 
 interface PropertyData {
@@ -19,7 +17,6 @@ interface PropertyData {
 
 export default function HomePage() {
     const [properties, setProperties] = useState<PropertyData[]>([]);
-    const { t } = useTranslation();
 
     useEffect(() => {
         async function load() {
@@ -42,17 +39,6 @@ export default function HomePage() {
     return (
         <div className="w-full bg-card font-sans text-title">
             <HeroSection />
-            {IS_DEMO_MODE && (
-                <div className="max-w-7xl mx-auto px-4 md:px-8 lg:px-16 -mt-24 relative z-20 pb-10">
-                    <div className="w-full bg-[#42211D] border border-white/20 shadow-xl rounded-xl p-4 sm:p-5 flex flex-col lg:flex-row lg:items-center gap-4 justify-between">
-                        <div>
-                            <p className="text-white text-lg font-black tracking-tight">{t('demo.poster')}</p>
-                            <p className="text-white/80 text-sm font-medium">{t('demo.exploreWithoutPassword')}</p>
-                        </div>
-                        <DemoRoleSelector compact />
-                    </div>
-                </div>
-            )}
             <FeaturesSection />
             <TopPropertiesSection properties={properties} />
             <ExploreSection />

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -7,7 +7,6 @@ import ExploreSection from '../components/landing/ExploreSection';
 import BlogSection from '../components/landing/BlogSection';
 import NewsletterSection from '../components/landing/NewsletterSection';
 import TrustBadges from '../components/landing/TrustBadges';
-import { useTranslation } from "react-i18next";
 
 interface PropertyData {
     id: string;


### PR DESCRIPTION
## Summary
This pull request addresses a severe UI bug on mobile devices and public views where a leftover developer/demo role-switching block (rendered within a dark brown container) was leaked at the bottom of the landing page. The block was rendering unconditionally when `IS_DEMO_MODE` was active, leading to layout issues and unintended exposure of internal host-specific feature routes (such as Dashboard, Reservations, and Properties) on the public landing page.

## Linked issue
Closes #215

## Scope of changes
- Completely removed the container div rendering the demo banner and `DemoRoleSelector` from `frontend/src/pages/HomePage.tsx`.
- Removed unused imports of `DemoRoleSelector`, `IS_DEMO_MODE`, and `useTranslation` in `frontend/src/pages/HomePage.tsx`.

## Testing status
- [x] Tested locally
- [x] Existing tests pass

## Checklist
- [x] PR title is clear and meaningful
- [x] Linked issue is included
- [x] Scope matches the issue
- [x] No unrelated changes were added
- [x] Ready for review